### PR TITLE
Set TAB display size in editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,6 +2,7 @@ root = true
 
 [*]
 indent_style = tab
+indent_size = 2
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true


### PR DESCRIPTION
Copied from
https://github.com/gfargo/ink-enhanced-select-input/blob/829492b6499104b6b40d505f223bea7a42b541d9/.prettierrc.json#L3

GitHub takes this into account.
Currently it defaults to 8!