### PR TITLE
Fix rapid keypress handling with functional setState

### DIFF
--- a/src/enhanced-select-input/index.tsx
+++ b/src/enhanced-select-input/index.tsx
@@ -116,30 +116,51 @@ export function EnhancedSelectInput<V>({
         return
       }
 
-      let nextIndex = selectedIndex
-
+      // Use functional setState to handle rapid keypresses correctly
+      // This ensures each keypress gets the latest index value, not a stale closure value
       if (orientation === 'vertical') {
         if (key.upArrow || input === 'k') {
-          nextIndex = findNextValidIndex(selectedIndex, -1)
+          setSelectedIndex(currentIndex => {
+            const nextIndex = findNextValidIndex(currentIndex, -1)
+            if (nextIndex !== currentIndex && limit) {
+              setRotateIndex(Math.floor(nextIndex / limit) * limit)
+            }
+            return nextIndex
+          })
+          return
         }
 
         if (key.downArrow || input === 'j') {
-          nextIndex = findNextValidIndex(selectedIndex, 1)
+          setSelectedIndex(currentIndex => {
+            const nextIndex = findNextValidIndex(currentIndex, 1)
+            if (nextIndex !== currentIndex && limit) {
+              setRotateIndex(Math.floor(nextIndex / limit) * limit)
+            }
+            return nextIndex
+          })
+          return
         }
       } else {
         if (key.leftArrow || input === 'h') {
-          nextIndex = findNextValidIndex(selectedIndex, -1)
+          setSelectedIndex(currentIndex => {
+            const nextIndex = findNextValidIndex(currentIndex, -1)
+            if (nextIndex !== currentIndex && limit) {
+              setRotateIndex(Math.floor(nextIndex / limit) * limit)
+            }
+            return nextIndex
+          })
+          return
         }
 
         if (key.rightArrow || input === 'l') {
-          nextIndex = findNextValidIndex(selectedIndex, 1)
-        }
-      }
-
-      if (nextIndex !== selectedIndex) {
-        setSelectedIndex(nextIndex)
-        if (limit) {
-          setRotateIndex(Math.floor(nextIndex / limit) * limit)
+          setSelectedIndex(currentIndex => {
+            const nextIndex = findNextValidIndex(currentIndex, 1)
+            if (nextIndex !== currentIndex && limit) {
+              setRotateIndex(Math.floor(nextIndex / limit) * limit)
+            }
+            return nextIndex
+          })
+          return
         }
       }
 


### PR DESCRIPTION
## Problem
When multiple arrow key presses arrived in rapid succession (e.g., from terminal automation or fast typing), only a single navigation step would occur instead of multiple steps.

## Root Cause
The `useInput` handler was using direct state updates:
```typescript
setSelectedIndex(nextIndex)
```

This caused React's state batching to consolidate multiple rapid keypresses. All keypresses read the same closure value of `selectedIndex` before React re-rendered, so they all calculated the same `nextIndex`, resulting in only one move.

## Solution
Use functional setState to ensure each keypress gets the latest index value:
```typescript
setSelectedIndex(currentIndex => {
  const nextIndex = findNextValidIndex(currentIndex, step)
  // ... handle rotation
  return nextIndex
})
```

This ensures each navigation handler reads the most recent state value, allowing rapid keypresses to be processed correctly.

## Changes
- Modified `src/enhanced-select-input/index.tsx` to use functional form of `setSelectedIndex`
- Added early returns after state updates to prevent fall-through logic
- Moved rotation logic inside the setState callback

## Testing
Tested with terminal automation sending multiple down arrow keys in quick succession - now correctly moves multiple positions instead of just one.

## Impact
This is a **bug fix** that improves the component's responsiveness for:
- Users with fast typing speeds
- Terminal automation tools
- Accessibility tools that programmatically send keypresses