### PR TITLE
feat: onCancel/Escape, Home/End keys, and bug fixes

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -131,13 +131,14 @@ function MyItem({ isSelected, isDisabled, label }) {
 | `itemComponent`      | `FC<ItemProps>`              | `DefaultItemComponent`      | Custom item renderer                     |
 | `onSelect`           | `(item: Item<V>) => void`    | —                           | Called on selection (Enter or hotkey)    |
 | `onHighlight`        | `(item: Item<V>) => void`    | —                           | Called when the highlighted item changes |
+| `onCancel`           | `() => void`                 | —                           | Called when Escape is pressed            |
 | `orientation`        | `'vertical' \| 'horizontal'` | `'vertical'`                | Layout direction                         |
 
 ### Item Shape
 
 ```ts
 type Item<V> = {
-  key?: string
+  key?: string        // Required when V is an object — see note below
   label: string
   value: V
   hotkey?: string
@@ -146,16 +147,22 @@ type Item<V> = {
 }
 ```
 
+> **`key` field:** React uses `key` (or `String(value)` as a fallback) to track
+> list items. When `V` is a non-primitive type such as an object, `String(value)`
+> always produces `"[object Object]"`, causing duplicate key warnings and
+> potential rendering bugs. Always set `key` to a stable unique string when
+> `value` is an object.
+
 ## Keyboard Navigation
 
-| Orientation | Previous  | Next      | Select  |
-| ----------- | --------- | --------- | ------- |
-| Vertical    | `↑` / `k` | `↓` / `j` | `Enter` |
-| Horizontal  | `←` / `h` | `→` / `l` | `Enter` |
+| Orientation | Previous  | Next      | First    | Last    | Select  | Cancel   |
+| ----------- | --------- | --------- | -------- | ------- | ------- | -------- |
+| Vertical    | `↑` / `k` | `↓` / `j` | `Home`   | `End`   | `Enter` | `Escape` |
+| Horizontal  | `←` / `h` | `→` / `l` | `Home`   | `End`   | `Enter` | `Escape` |
 
-Hotkeys (when assigned) select the item immediately.
+Hotkeys (when assigned) select the item immediately. Disabled items are automatically skipped during navigation, including by `Home` and `End`.
 
-Disabled items are automatically skipped during navigation.
+`Escape` calls the `onCancel` prop when provided — useful for multi-step CLI flows that need a "go back" action.
 
 > **Hotkey constraints:** Navigation keys take priority over hotkeys. In vertical
 > orientation the characters `j` and `k` are reserved for navigation — an item

--- a/src/enhanced-select-input/index.tsx
+++ b/src/enhanced-select-input/index.tsx
@@ -2,6 +2,11 @@ import { Box, Text, useInput } from 'ink'
 import React, { type FC, useEffect, useState } from 'react'
 
 export type Item<V> = {
+  /**
+   * Unique key for React rendering. Required when V is a non-primitive type
+   * (e.g. object) — without it, String(value) produces "[object Object]" for
+   * every item, causing duplicate React key warnings and rendering bugs.
+   */
   key?: string
   label: string
   value: V
@@ -19,6 +24,8 @@ export type Properties<V> = {
   readonly itemComponent?: FC<ItemProperties>
   readonly onSelect?: (item: Item<V>) => void
   readonly onHighlight?: (item: Item<V>) => void
+  /** Called when Escape is pressed while the component is focused. */
+  readonly onCancel?: () => void
   readonly orientation?: 'vertical' | 'horizontal'
 }
 
@@ -75,6 +82,22 @@ function findNextValidIndex<V>(
   return currentIndex
 }
 
+function findFirstValidIndex<V>(items: Array<Item<V>>): number {
+  for (let i = 0; i < items.length; i++) {
+    if (!items[i]?.disabled) return i
+  }
+
+  return 0
+}
+
+function findLastValidIndex<V>(items: Array<Item<V>>): number {
+  for (let i = items.length - 1; i >= 0; i--) {
+    if (!items[i]?.disabled) return i
+  }
+
+  return items.length - 1
+}
+
 export function DefaultIndicatorComponent({ isSelected }: IndicatorProperties) {
   return (
     <Box marginRight={1}>
@@ -109,6 +132,7 @@ export function EnhancedSelectInput<V>({
   limit,
   onSelect,
   onHighlight,
+  onCancel,
   orientation = 'vertical',
 }: Properties<V>) {
   const safeInitialIndex = resolveInitialIndex(items, initialIndex)
@@ -122,6 +146,9 @@ export function EnhancedSelectInput<V>({
     : items
   const hasItems = items.length > 0
 
+  // Only re-fire when the highlighted index changes, not when the items
+  // array reference changes (which would cause spurious calls on every
+  // parent re-render that passes a new array with identical content).
   useEffect(() => {
     if (hasItems) {
       const highlightedItem = items[selectedIndex]
@@ -129,16 +156,42 @@ export function EnhancedSelectInput<V>({
         onHighlight?.(highlightedItem)
       }
     }
-  }, [items, selectedIndex, onHighlight, hasItems])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedIndex, onHighlight, hasItems])
+
+  const updateSelection = (nextIndex: number) => {
+    setSelectedIndex(nextIndex)
+    if (limit) {
+      setRotateIndex(Math.floor(nextIndex / limit) * limit)
+    }
+  }
 
   useInput(
     (input, key) => {
       if (!hasItems) return
 
-      let nextIndex = selectedIndex
       const navKeys =
         orientation === 'vertical' ? VERTICAL_NAV_KEYS : HORIZONTAL_NAV_KEYS
       const isNavKey = navKeys.has(input)
+
+      // Home / End — jump to first or last enabled item
+      if (key.home) {
+        updateSelection(findFirstValidIndex(items))
+        return
+      }
+
+      if (key.end) {
+        updateSelection(findLastValidIndex(items))
+        return
+      }
+
+      // Escape — cancel / dismiss
+      if (key.escape) {
+        onCancel?.()
+        return
+      }
+
+      let nextIndex = selectedIndex
 
       if (orientation === 'vertical') {
         if (key.upArrow || input === 'k') {
@@ -159,10 +212,7 @@ export function EnhancedSelectInput<V>({
       }
 
       if (nextIndex !== selectedIndex) {
-        setSelectedIndex(nextIndex)
-        if (limit) {
-          setRotateIndex(Math.floor(nextIndex / limit) * limit)
-        }
+        updateSelection(nextIndex)
       }
 
       if (key.return) {
@@ -180,11 +230,7 @@ export function EnhancedSelectInput<V>({
         )
         if (hotkeyItem) {
           const hotkeyIndex = items.indexOf(hotkeyItem)
-          setSelectedIndex(hotkeyIndex)
-          if (limit) {
-            setRotateIndex(Math.floor(hotkeyIndex / limit) * limit)
-          }
-
+          updateSelection(hotkeyIndex)
           onSelect?.(hotkeyItem)
         }
       }

--- a/src/test/enhanced-select-input.test.tsx
+++ b/src/test/enhanced-select-input.test.tsx
@@ -13,6 +13,9 @@ const ARROW_DOWN = '\u001B[B'
 const ARROW_RIGHT = '\u001B[C'
 const ARROW_LEFT = '\u001B[D'
 const ENTER = '\r'
+const ESCAPE = '\u001B'
+const HOME = '\u001B[H'
+const END = '\u001B[F'
 
 // Small delay to let React/Ink process state updates
 const delay = async (ms = 50) =>
@@ -924,4 +927,215 @@ test('horizontal navigation wraps around from first to last', async (t) => {
   stdin.write(ARROW_LEFT)
   await delay()
   t.is(highlighted, 'B')
+})
+
+// --- onCancel (Escape key) ---
+
+test('Escape calls onCancel', async (t) => {
+  const items = [
+    { label: 'A', value: 'a' },
+    { label: 'B', value: 'b' },
+  ]
+
+  let cancelled = false
+  const { stdin } = render(
+    <EnhancedSelectInput
+      items={items}
+      onCancel={() => {
+        cancelled = true
+      }}
+    />
+  )
+
+  await delay()
+  stdin.write(ESCAPE)
+  await delay()
+  t.true(cancelled)
+})
+
+test('Escape does not call onCancel when isFocused=false', async (t) => {
+  const items = [
+    { label: 'A', value: 'a' },
+    { label: 'B', value: 'b' },
+  ]
+
+  let cancelled = false
+  const { stdin } = render(
+    <EnhancedSelectInput
+      items={items}
+      isFocused={false}
+      onCancel={() => {
+        cancelled = true
+      }}
+    />
+  )
+
+  await delay()
+  stdin.write(ESCAPE)
+  await delay()
+  t.false(cancelled)
+})
+
+test('Escape is a no-op when onCancel is not provided', async (t) => {
+  const items = [{ label: 'A', value: 'a' }]
+
+  let highlighted = ''
+  const { stdin } = render(
+    <EnhancedSelectInput
+      items={items}
+      onHighlight={(item) => {
+        highlighted = item.label
+      }}
+    />
+  )
+
+  await delay()
+  stdin.write(ESCAPE)
+  await delay()
+  // Component keeps working normally after an ignored Escape
+  t.is(highlighted, 'A')
+})
+
+// --- Home / End keys ---
+
+test('Home key jumps to first enabled item', async (t) => {
+  const items = [
+    { label: 'A', value: 'a' },
+    { label: 'B', value: 'b' },
+    { label: 'C', value: 'c' },
+  ]
+
+  let highlighted = ''
+  const { stdin } = render(
+    <EnhancedSelectInput
+      items={items}
+      initialIndex={2}
+      onHighlight={(item) => {
+        highlighted = item.label
+      }}
+    />
+  )
+
+  await delay()
+  t.is(highlighted, 'C')
+
+  stdin.write(HOME)
+  await delay()
+  t.is(highlighted, 'A')
+})
+
+test('End key jumps to last enabled item', async (t) => {
+  const items = [
+    { label: 'A', value: 'a' },
+    { label: 'B', value: 'b' },
+    { label: 'C', value: 'c' },
+  ]
+
+  let highlighted = ''
+  const { stdin } = render(
+    <EnhancedSelectInput
+      items={items}
+      onHighlight={(item) => {
+        highlighted = item.label
+      }}
+    />
+  )
+
+  await delay()
+  t.is(highlighted, 'A')
+
+  stdin.write(END)
+  await delay()
+  t.is(highlighted, 'C')
+})
+
+test('Home skips leading disabled items', async (t) => {
+  const items = [
+    { label: 'A', value: 'a', disabled: true },
+    { label: 'B', value: 'b', disabled: true },
+    { label: 'C', value: 'c' },
+    { label: 'D', value: 'd' },
+  ]
+
+  let highlighted = ''
+  const { stdin } = render(
+    <EnhancedSelectInput
+      items={items}
+      initialIndex={3}
+      onHighlight={(item) => {
+        highlighted = item.label
+      }}
+    />
+  )
+
+  await delay()
+  t.is(highlighted, 'D')
+
+  stdin.write(HOME)
+  await delay()
+  t.is(highlighted, 'C')
+})
+
+test('End skips trailing disabled items', async (t) => {
+  const items = [
+    { label: 'A', value: 'a' },
+    { label: 'B', value: 'b' },
+    { label: 'C', value: 'c', disabled: true },
+    { label: 'D', value: 'd', disabled: true },
+  ]
+
+  let highlighted = ''
+  const { stdin } = render(
+    <EnhancedSelectInput
+      items={items}
+      onHighlight={(item) => {
+        highlighted = item.label
+      }}
+    />
+  )
+
+  await delay()
+  stdin.write(END)
+  await delay()
+  t.is(highlighted, 'B')
+})
+
+test('Home/End update rotateIndex when limit is active', async (t) => {
+  const items = [
+    { label: 'A', value: 'a' },
+    { label: 'B', value: 'b' },
+    { label: 'C', value: 'c' },
+    { label: 'D', value: 'd' },
+  ]
+
+  let highlighted = ''
+  const { stdin, lastFrame } = render(
+    <EnhancedSelectInput
+      items={items}
+      limit={2}
+      initialIndex={0}
+      onHighlight={(item) => {
+        highlighted = item.label
+      }}
+    />
+  )
+
+  await delay()
+  t.is(highlighted, 'A')
+
+  stdin.write(END)
+  await delay()
+  t.is(highlighted, 'D')
+
+  // Window should have scrolled to show D
+  const frame = lastFrame()!
+  t.true(frame.includes('D'))
+
+  stdin.write(HOME)
+  await delay()
+  t.is(highlighted, 'A')
+
+  // Window should have scrolled back to show A
+  const frame2 = lastFrame()!
+  t.true(frame2.includes('A'))
 })


### PR DESCRIPTION
## Summary

Closes #10, #11, #16, #17

### Bug fixes

- **#17 — Spurious `onHighlight`:** Removed `items` from the `useEffect` dependency array. The callback is semantically tied to `selectedIndex` changing, not to array reference identity — parent components that pass a fresh array on every render no longer trigger phantom highlight events.
- **#16 — Object-valued item keys:** Added a JSDoc note to `Item<V>.key` and a callout in the README explaining that `key` is required when `V` is a non-primitive; without it `String(value)` yields `"[object Object]"` for every item.

### New features

- **#11 — `onCancel` prop:** Pressing `Escape` while focused calls `onCancel()` when provided. Covers the common multi-step CLI pattern of "press Escape to go back" without requiring a parent-level `useInput` intercept. No-op when not provided.
- **#10 — `Home` / `End` keys:** Jump directly to the first or last enabled item. Both skip over disabled items at the list boundaries and correctly update `rotateIndex` when `limit` pagination is active.

### Refactor

- Extracted `updateSelection` helper (deduplicates the `setSelectedIndex` + `setRotateIndex` pair that appeared in multiple branches).
- Added `findFirstValidIndex` / `findLastValidIndex` as module-level utilities alongside the existing `findNextValidIndex`.

## Test plan

- [x] `yarn build` — no TypeScript errors
- [x] `yarn test` — 42/42 pass (8 new tests)

| New test | What it covers |
|----------|----------------|
| Escape calls onCancel | Basic onCancel firing |
| Escape no-op when isFocused=false | isActive gate respected |
| Escape no-op when onCancel not provided | Safe when prop omitted |
| Home jumps to first enabled item | Basic Home behavior |
| End jumps to last enabled item | Basic End behavior |
| Home skips leading disabled items | Disabled boundary handling |
| End skips trailing disabled items | Disabled boundary handling |
| Home/End update rotateIndex with limit | Pagination + jump interaction |

🤖 Generated with [Claude Code](https://claude.com/claude-code)