### PR TITLE
feat: showScrollIndicators prop for paginated lists

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -133,6 +133,7 @@ function MyItem({ isSelected, isDisabled, label }) {
 | `onHighlight`        | `(item: Item<V>) => void`    | —                           | Called when the highlighted item changes |
 | `onCancel`           | `() => void`                 | —                           | Called when Escape is pressed            |
 | `orientation`        | `'vertical' \| 'horizontal'` | `'vertical'`                | Layout direction                         |
+| `showScrollIndicators` | `boolean`                  | `false`                     | Show ▲/▼ or ◀/▶ counts when `limit` clips the list |
 
 ### Item Shape
 

--- a/src/enhanced-select-input/index.tsx
+++ b/src/enhanced-select-input/index.tsx
@@ -27,6 +27,12 @@ export type Properties<V> = {
   /** Called when Escape is pressed while the component is focused. */
   readonly onCancel?: () => void
   readonly orientation?: 'vertical' | 'horizontal'
+  /**
+   * Show ▲/▼ (vertical) or ◀/▶ (horizontal) indicators with item counts
+   * when the limit window doesn't cover the full list. Only meaningful when
+   * `limit` is set. Defaults to false.
+   */
+  readonly showScrollIndicators?: boolean
 }
 
 export type IndicatorProperties = {
@@ -134,6 +140,7 @@ export function EnhancedSelectInput<V>({
   onHighlight,
   onCancel,
   orientation = 'vertical',
+  showScrollIndicators = false,
 }: Properties<V>) {
   const safeInitialIndex = resolveInitialIndex(items, initialIndex)
   const [selectedIndex, setSelectedIndex] = useState(safeInitialIndex)
@@ -145,6 +152,9 @@ export function EnhancedSelectInput<V>({
     ? items.slice(rotateIndex, rotateIndex + limit)
     : items
   const hasItems = items.length > 0
+
+  const itemsAbove = rotateIndex
+  const itemsBelow = limit ? Math.max(0, items.length - rotateIndex - limit) : 0
 
   // Only re-fire when the highlighted index changes, not when the items
   // array reference changes (which would cause spurious calls on every
@@ -244,38 +254,51 @@ export function EnhancedSelectInput<V>({
 
   const IndicatorComponent = indicatorComponent
   const ItemComponent = itemComponent
+  const isVertical = orientation === 'vertical'
 
   return (
-    <Box
-      flexDirection={orientation === 'vertical' ? 'column' : 'row'}
-      gap={orientation === 'vertical' ? 0 : 2}
-    >
-      {visibleItems.map((item, index) => {
-        const isSelected = index + rotateIndex === selectedIndex
+    <Box flexDirection={isVertical ? 'column' : 'row'}>
+      {showScrollIndicators && itemsAbove > 0 && (
+        <Box marginRight={isVertical ? 0 : 1}>
+          <Text dimColor>{isVertical ? `▲ ${itemsAbove} more` : `◀ ${itemsAbove} more`}</Text>
+        </Box>
+      )}
+      <Box
+        flexDirection={isVertical ? 'column' : 'row'}
+        gap={isVertical ? 0 : 2}
+      >
+        {visibleItems.map((item, index) => {
+          const isSelected = index + rotateIndex === selectedIndex
 
-        return (
-          <Box key={item.key ?? String(item.value)}>
-            {item.indicator ? (
-              <Box marginRight={1}>
-                <Text>{isSelected ? item.indicator : ' '}</Text>
-              </Box>
-            ) : (
-              <IndicatorComponent isSelected={isSelected} item={item} />
-            )}
-            <ItemComponent
-              isSelected={isSelected}
-              label={item.label}
-              isDisabled={Boolean(item.disabled)}
-            />
-            {item.hotkey && (
-              <Text dimColor color="gray">
-                {' '}
-                ({item.hotkey})
-              </Text>
-            )}
-          </Box>
-        )
-      })}
+          return (
+            <Box key={item.key ?? String(item.value)}>
+              {item.indicator ? (
+                <Box marginRight={1}>
+                  <Text>{isSelected ? item.indicator : ' '}</Text>
+                </Box>
+              ) : (
+                <IndicatorComponent isSelected={isSelected} item={item} />
+              )}
+              <ItemComponent
+                isSelected={isSelected}
+                label={item.label}
+                isDisabled={Boolean(item.disabled)}
+              />
+              {item.hotkey && (
+                <Text dimColor color="gray">
+                  {' '}
+                  ({item.hotkey})
+                </Text>
+              )}
+            </Box>
+          )
+        })}
+      </Box>
+      {showScrollIndicators && itemsBelow > 0 && (
+        <Box marginLeft={isVertical ? 0 : 1}>
+          <Text dimColor>{isVertical ? `▼ ${itemsBelow} more` : `▶ ${itemsBelow} more`}</Text>
+        </Box>
+      )}
     </Box>
   )
 }

--- a/src/test/enhanced-select-input.test.tsx
+++ b/src/test/enhanced-select-input.test.tsx
@@ -1139,3 +1139,90 @@ test('Home/End update rotateIndex when limit is active', async (t) => {
   const frame2 = lastFrame()!
   t.true(frame2.includes('A'))
 })
+
+// --- showScrollIndicators ---
+
+test('showScrollIndicators shows below indicator when items are clipped', (t) => {
+  const items = [
+    { label: 'A', value: 'a' },
+    { label: 'B', value: 'b' },
+    { label: 'C', value: 'c' },
+    { label: 'D', value: 'd' },
+  ]
+
+  const { lastFrame } = render(
+    <EnhancedSelectInput items={items} limit={2} showScrollIndicators />
+  )
+
+  const frame = lastFrame()!
+  t.true(frame.includes('▼'))
+  t.true(frame.includes('2 more'))
+  t.false(frame.includes('▲'))
+})
+
+test('showScrollIndicators shows both indicators when window is mid-list', async (t) => {
+  // 6 items, limit=2, start at index 2 → window [C,D], 2 above, 2 below
+  const items = [
+    { label: 'A', value: 'a' },
+    { label: 'B', value: 'b' },
+    { label: 'C', value: 'c' },
+    { label: 'D', value: 'd' },
+    { label: 'E', value: 'e' },
+    { label: 'F', value: 'f' },
+  ]
+
+  const { stdin, lastFrame } = render(
+    <EnhancedSelectInput
+      items={items}
+      limit={2}
+      showScrollIndicators
+      initialIndex={2}
+    />
+  )
+
+  await delay()
+  const frame = lastFrame()!
+  t.true(frame.includes('▲'))
+  t.true(frame.includes('▼'))
+  t.true(frame.includes('2 more'))
+
+  // Navigate to last window (E/F) — no more below
+  stdin.write(ARROW_DOWN)
+  await delay()
+  stdin.write(ARROW_DOWN)
+  await delay()
+  const frame2 = lastFrame()!
+  t.true(frame2.includes('▲'))
+  t.false(frame2.includes('▼'))
+})
+
+test('showScrollIndicators hidden by default', (t) => {
+  const items = [
+    { label: 'A', value: 'a' },
+    { label: 'B', value: 'b' },
+    { label: 'C', value: 'c' },
+  ]
+
+  const { lastFrame } = render(
+    <EnhancedSelectInput items={items} limit={2} />
+  )
+
+  const frame = lastFrame()!
+  t.false(frame.includes('▲'))
+  t.false(frame.includes('▼'))
+})
+
+test('showScrollIndicators not shown when all items fit in window', (t) => {
+  const items = [
+    { label: 'A', value: 'a' },
+    { label: 'B', value: 'b' },
+  ]
+
+  const { lastFrame } = render(
+    <EnhancedSelectInput items={items} limit={5} showScrollIndicators />
+  )
+
+  const frame = lastFrame()!
+  t.false(frame.includes('▲'))
+  t.false(frame.includes('▼'))
+})


### PR DESCRIPTION
Closes #9

## Summary

When `limit` clips the item list, users have no way to know more items exist outside the visible window. `showScrollIndicators` adds count lines above/below (or left/right for horizontal) the window:

```
  ▲ 2 more
> Item C
  Item D
  ▼ 2 more
```

- Vertical orientation: `▲ N more` / `▼ N more`
- Horizontal orientation: `◀ N more` / `▶ N more`
- Indicators appear only when there are items outside the current window
- Both can be visible simultaneously when the window is mid-list
- **Opt-in** (`showScrollIndicators` defaults to `false`) — no change to existing render output

## Test plan

- [x] `yarn build` — no errors
- [x] `yarn test` — 46/46 pass (4 new tests)

| New test | What it covers |
|----------|----------------|
| shows below indicator when items are clipped | Initial state at top of list |
| shows both indicators when window is mid-list | Mid-list window, then scrolls to end |
| hidden by default | Default prop is false |
| not shown when all items fit in window | No indicators when limit > items.length |

🤖 Generated with [Claude Code](https://claude.com/claude-code)