### PR TITLE
fix: re-sync selection when items prop changes after mount

### DIFF
--- a/src/enhanced-select-input/index.tsx
+++ b/src/enhanced-select-input/index.tsx
@@ -152,6 +152,21 @@ export function useEnhancedSelectInput<V>({
   const itemsAbove = rotateIndex
   const itemsBelow = limit ? Math.max(0, items.length - rotateIndex - limit) : 0
 
+  // When the items array changes, re-validate the current selectedIndex.
+  // If the item at that position is still enabled we keep it; otherwise we
+  // resolve the nearest valid index from the same position, so the selection
+  // stays as close as possible to where the user left off.
+  useEffect(() => {
+    if (items.length === 0) return
+    const currentItem = items[selectedIndex]
+    if (!currentItem || currentItem.disabled) {
+      const newIndex = resolveInitialIndex(items, selectedIndex)
+      setSelectedIndex(newIndex)
+      if (limit) setRotateIndex(Math.floor(newIndex / limit) * limit)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [items])
+
   // Only re-fire when the highlighted index changes, not when the items
   // array reference changes (which would cause spurious calls on every
   // parent re-render that passes a new array with identical content).

--- a/src/test/enhanced-select-input.test.tsx
+++ b/src/test/enhanced-select-input.test.tsx
@@ -1344,3 +1344,127 @@ test('hook returns empty state for empty items', async (t) => {
   t.is(result?.hasItems, false)
   t.is(result?.visibleItems.length, 0)
 })
+
+// --- #15: items prop sync after mount ---
+
+test('selection clamps when items shrink below current index', async (t) => {
+  const initialItems = [
+    { label: 'A', value: 'a' },
+    { label: 'B', value: 'b' },
+    { label: 'C', value: 'c' },
+  ]
+
+  let highlighted = ''
+
+  const { rerender } = render(
+    <EnhancedSelectInput
+      items={initialItems}
+      initialIndex={2}
+      onHighlight={(item) => {
+        highlighted = item.label
+      }}
+    />
+  )
+
+  await delay()
+  t.is(highlighted, 'C')
+
+  // Shrink to 2 items — index 2 no longer exists
+  rerender(
+    <EnhancedSelectInput
+      items={[
+        { label: 'A', value: 'a' },
+        { label: 'B', value: 'b' },
+      ]}
+      initialIndex={2}
+      onHighlight={(item) => {
+        highlighted = item.label
+      }}
+    />
+  )
+
+  await delay()
+  t.is(highlighted, 'B')
+})
+
+test('selection moves off a now-disabled item when items update', async (t) => {
+  const items = [
+    { label: 'A', value: 'a' },
+    { label: 'B', value: 'b' },
+    { label: 'C', value: 'c' },
+  ]
+
+  let highlighted = ''
+
+  const { rerender } = render(
+    <EnhancedSelectInput
+      items={items}
+      initialIndex={1}
+      onHighlight={(item) => {
+        highlighted = item.label
+      }}
+    />
+  )
+
+  await delay()
+  t.is(highlighted, 'B')
+
+  // Mark B as disabled — selection should move to nearest enabled item
+  rerender(
+    <EnhancedSelectInput
+      items={[
+        { label: 'A', value: 'a' },
+        { label: 'B', value: 'b', disabled: true },
+        { label: 'C', value: 'c' },
+      ]}
+      initialIndex={1}
+      onHighlight={(item) => {
+        highlighted = item.label
+      }}
+    />
+  )
+
+  await delay()
+  t.not(highlighted, 'B')
+})
+
+test('selection preserved when items update but current slot is still valid', async (t) => {
+  const items = [
+    { label: 'A', value: 'a' },
+    { label: 'B', value: 'b' },
+    { label: 'C', value: 'c' },
+  ]
+
+  let highlighted = ''
+
+  const { rerender } = render(
+    <EnhancedSelectInput
+      items={items}
+      initialIndex={1}
+      onHighlight={(item) => {
+        highlighted = item.label
+      }}
+    />
+  )
+
+  await delay()
+  t.is(highlighted, 'B')
+
+  // Replace with fresh reference, same content — selection must stay on B
+  rerender(
+    <EnhancedSelectInput
+      items={[
+        { label: 'A', value: 'a' },
+        { label: 'B', value: 'b' },
+        { label: 'C', value: 'c' },
+      ]}
+      initialIndex={1}
+      onHighlight={(item) => {
+        highlighted = item.label
+      }}
+    />
+  )
+
+  await delay()
+  t.is(highlighted, 'B')
+})


### PR DESCRIPTION
Closes #15

## Summary

`EnhancedSelectInput` was an uncontrolled component — `selectedIndex` was only initialised once and silently went stale when the `items` prop changed after mount. A stale index could point to an undefined slot (if items shrank) or a now-disabled item, with no visible error.

This PR adds a `useEffect` inside `useEnhancedSelectInput` that re-validates `selectedIndex` whenever `items` changes:

| Scenario | Old behaviour | New behaviour |
|----------|---------------|---------------|
| Items shrink past `selectedIndex` | Out-of-bounds, nothing appears selected | Clamps to last valid item |
| Item at `selectedIndex` becomes disabled | Disabled item stays highlighted | Moves to nearest enabled item |
| Items replaced with same content (new ref) | No change | No change (slot still valid → preserved) |
| All items become disabled | Stays put | Stays put (unchanged) |

The resolution always uses `resolveInitialIndex(items, selectedIndex)` — nearest forward search from the current position — so selection stays as close as possible to where the user was.

## Test plan

- [x] `yarn build` — no TypeScript errors
- [x] `yarn test` — 53/53 pass (3 new tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)