### PR TITLE
fix: dev warning for duplicate item keys (#16), close #17

### DIFF
--- a/src/enhanced-select-input/index.tsx
+++ b/src/enhanced-select-input/index.tsx
@@ -156,7 +156,27 @@ export function useEnhancedSelectInput<V>({
   // If the item at that position is still enabled we keep it; otherwise we
   // resolve the nearest valid index from the same position, so the selection
   // stays as close as possible to where the user left off.
+  // Also warn in development when duplicate React keys are detected —
+  // this happens when V is an object and item.key is not set, causing
+  // String(value) to produce "[object Object]" for every item.
   useEffect(() => {
+    if (process.env['NODE_ENV'] !== 'production' && items.length > 0) {
+      const keys = items.map((item) => item.key ?? String(item.value))
+      const seen = new Set<string>()
+      const duplicates = new Set<string>()
+      for (const k of keys) {
+        if (seen.has(k)) duplicates.add(k)
+        else seen.add(k)
+      }
+
+      if (duplicates.size > 0) {
+        console.warn(
+          `[ink-enhanced-select-input] Duplicate item keys detected: ${[...duplicates].join(', ')}. ` +
+            'Set a unique "key" on each item — this is required when value is a non-primitive type (e.g. object).'
+        )
+      }
+    }
+
     if (items.length === 0) return
     const currentItem = items[selectedIndex]
     if (!currentItem || currentItem.disabled) {

--- a/src/test/enhanced-select-input.test.tsx
+++ b/src/test/enhanced-select-input.test.tsx
@@ -1468,3 +1468,54 @@ test('selection preserved when items update but current slot is still valid', as
   await delay()
   t.is(highlighted, 'B')
 })
+
+// --- #16: duplicate key warning ---
+
+test('warns in development when object-valued items have no key field', async (t) => {
+  const warnings: string[] = []
+  const originalWarn = console.warn
+  console.warn = (...args: unknown[]) => {
+    warnings.push(String(args[0]))
+  }
+
+  try {
+    render(
+      <EnhancedSelectInput
+        items={[
+          { label: 'A', value: { id: 1 } },
+          { label: 'B', value: { id: 2 } },
+        ]}
+      />
+    )
+
+    await delay()
+    t.true(warnings.some((w) => w.includes('[ink-enhanced-select-input]')))
+    t.true(warnings.some((w) => w.includes('Duplicate item keys')))
+  } finally {
+    console.warn = originalWarn
+  }
+})
+
+test('no duplicate key warning when all items have explicit keys', async (t) => {
+  const warnings: string[] = []
+  const originalWarn = console.warn
+  console.warn = (...args: unknown[]) => {
+    warnings.push(String(args[0]))
+  }
+
+  try {
+    render(
+      <EnhancedSelectInput
+        items={[
+          { key: 'item-1', label: 'A', value: { id: 1 } },
+          { key: 'item-2', label: 'B', value: { id: 2 } },
+        ]}
+      />
+    )
+
+    await delay()
+    t.false(warnings.some((w) => w.includes('[ink-enhanced-select-input]')))
+  } finally {
+    console.warn = originalWarn
+  }
+})


### PR DESCRIPTION
## Summary

### Closes #16 — duplicate React keys for object-valued items

Items with non-primitive values (objects) and no explicit `key` field produce `String(value) = "[object Object]"` as the React key for every row, causing silent duplicate-key bugs that are hard to trace.

A dev-only `console.warn` now fires when duplicate computed keys are detected:

```
[ink-enhanced-select-input] Duplicate item keys detected: [object Object].
Set a unique "key" on each item — this is required when value is a non-primitive type (e.g. object).
```

The check lives in the existing `items`-change `useEffect` so it runs on mount and on every items update. It is a no-op in production (`process.env.NODE_ENV === 'production'`).

### Closes #17 — spurious onHighlight

Already resolved in PR #19 (v0.5.0). Closing via issue comment.

## Test plan

- [x] `yarn build` — no TypeScript errors
- [x] `yarn test` — 55/55 pass (2 new tests)

| New test | What it covers |
|----------|----------------|
| warns in development when object-valued items have no key field | Warning fires with correct message |
| no duplicate key warning when all items have explicit keys | No false positives |

🤖 Generated with [Claude Code](https://claude.com/claude-code)