### PR TITLE
feat: multi-select mode

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -17,6 +17,7 @@ An enhanced, customizable select input component for [Ink](https://github.com/va
 - **Keyboard Navigation:** Arrow keys and Vim-like keys (`h/j/k/l`) supported.
 - **Hooks for Highlight & Selection:** Run custom logic on highlight and selection changes.
 - **Limit Displayed Items:** Restrict how many options to show at once.
+- **Multi-select Mode:** Space to toggle, Enter to confirm a multi-item selection.
 
 ## Compatibility
 
@@ -75,6 +76,41 @@ render(<Demo />)
   orientation="horizontal"
   onSelect={(item) => console.log(item.value)}
 />
+```
+
+### Multi-select
+
+Enable multi-select mode with the `multiple` prop. Space toggles an item; Enter confirms the full selection.
+
+```tsx
+import React, { useState } from 'react'
+import { render, Text } from 'ink'
+import { EnhancedSelectInput } from 'ink-enhanced-select-input'
+
+const options = [
+  { label: 'TypeScript', value: 'ts' },
+  { label: 'React', value: 'react' },
+  { label: 'Ink', value: 'ink' },
+  { label: 'Legacy (unsupported)', value: 'legacy', disabled: true },
+]
+
+function MultiDemo() {
+  return (
+    <EnhancedSelectInput
+      items={options}
+      multiple
+      defaultSelectedKeys={['ts']}
+      onToggle={(item, checked) =>
+        console.log(`${item.label} is now ${checked ? 'checked' : 'unchecked'}`)
+      }
+      onConfirm={(selected) =>
+        console.log('Confirmed:', selected.map((i) => i.value))
+      }
+    />
+  )
+}
+
+render(<MultiDemo />)
 ```
 
 ### Per-Item Indicators
@@ -144,23 +180,27 @@ function MyCustomSelect({ items, onSelect }) {
 }
 ```
 
-The hook accepts all the same props as `EnhancedSelectInput` except `indicatorComponent`, `itemComponent`, and `showScrollIndicators`. It returns `{ selectedIndex, rotateIndex, visibleItems, hasItems, itemsAbove, itemsBelow }`.
+The hook accepts all the same props as `EnhancedSelectInput` except `indicatorComponent`, `itemComponent`, and `showScrollIndicators`. It returns `{ selectedIndex, rotateIndex, visibleItems, hasItems, itemsAbove, itemsBelow, checkedKeys }`. `checkedKeys` is a `Set<string>` of checked item keys — only populated when `multiple` is `true`.
 
 ## Props
 
-| Prop                 | Type                         | Default                     | Description                              |
-| -------------------- | ---------------------------- | --------------------------- | ---------------------------------------- |
-| `items`              | `Array<Item<V>>`             | _required_                  | List of selectable items                 |
-| `isFocused`          | `boolean`                    | `true`                      | Whether the component responds to input  |
-| `initialIndex`       | `number`                     | `0`                         | Index of the initially highlighted item  |
-| `limit`              | `number`                     | —                           | Max number of visible items              |
-| `indicatorComponent` | `FC<IndicatorProps>`         | `DefaultIndicatorComponent` | Custom selection indicator               |
-| `itemComponent`      | `FC<ItemProps>`              | `DefaultItemComponent`      | Custom item renderer                     |
-| `onSelect`           | `(item: Item<V>) => void`    | —                           | Called on selection (Enter or hotkey)    |
-| `onHighlight`        | `(item: Item<V>) => void`    | —                           | Called when the highlighted item changes |
-| `onCancel`           | `() => void`                 | —                           | Called when Escape is pressed            |
-| `orientation`        | `'vertical' \| 'horizontal'` | `'vertical'`                | Layout direction                         |
-| `showScrollIndicators` | `boolean`                  | `false`                     | Show ▲/▼ or ◀/▶ counts when `limit` clips the list |
+| Prop                   | Type                              | Default                     | Description                              |
+| ---------------------- | --------------------------------- | --------------------------- | ---------------------------------------- |
+| `items`                | `Array<Item<V>>`                  | _required_                  | List of selectable items                 |
+| `isFocused`            | `boolean`                         | `true`                      | Whether the component responds to input  |
+| `initialIndex`         | `number`                          | `0`                         | Index of the initially highlighted item  |
+| `limit`                | `number`                          | —                           | Max number of visible items              |
+| `indicatorComponent`   | `FC<IndicatorProps>`              | `DefaultIndicatorComponent` | Custom selection indicator               |
+| `itemComponent`        | `FC<ItemProps>`                   | `DefaultItemComponent`      | Custom item renderer                     |
+| `onSelect`             | `(item: Item<V>) => void`         | —                           | Called on selection (Enter or hotkey) — single-select only |
+| `onHighlight`          | `(item: Item<V>) => void`         | —                           | Called when the highlighted item changes |
+| `onCancel`             | `() => void`                      | —                           | Called when Escape is pressed            |
+| `orientation`          | `'vertical' \| 'horizontal'`      | `'vertical'`                | Layout direction                         |
+| `showScrollIndicators` | `boolean`                         | `false`                     | Show ▲/▼ or ◀/▶ counts when `limit` clips the list |
+| `multiple`             | `boolean`                         | `false`                     | Enable multi-select mode (Space toggles, Enter confirms) |
+| `defaultSelectedKeys`  | `string[]`                        | —                           | Pre-checked item keys for multi-select   |
+| `onConfirm`            | `(items: Array<Item<V>>) => void` | —                           | Called on Enter in multi-select mode with all checked items |
+| `onToggle`             | `(item: Item<V>, checked: boolean) => void` | —             | Called each time an item is toggled in multi-select mode |
 
 ### Item Shape
 
@@ -183,12 +223,14 @@ type Item<V> = {
 
 ## Keyboard Navigation
 
-| Orientation | Previous  | Next      | First    | Last    | Select  | Cancel   |
-| ----------- | --------- | --------- | -------- | ------- | ------- | -------- |
-| Vertical    | `↑` / `k` | `↓` / `j` | `Home`   | `End`   | `Enter` | `Escape` |
-| Horizontal  | `←` / `h` | `→` / `l` | `Home`   | `End`   | `Enter` | `Escape` |
+| Orientation | Previous  | Next      | First    | Last    | Select / Confirm | Toggle (multi) | Cancel   |
+| ----------- | --------- | --------- | -------- | ------- | ---------------- | -------------- | -------- |
+| Vertical    | `↑` / `k` | `↓` / `j` | `Home`   | `End`   | `Enter`          | `Space`        | `Escape` |
+| Horizontal  | `←` / `h` | `→` / `l` | `Home`   | `End`   | `Enter`          | `Space`        | `Escape` |
 
-Hotkeys (when assigned) select the item immediately. Disabled items are automatically skipped during navigation, including by `Home` and `End`.
+In **single-select** mode, `Enter` calls `onSelect` and hotkeys select immediately. In **multi-select** mode (`multiple={true}`), `Space` toggles the highlighted item and `Enter` calls `onConfirm` with all checked items. Hotkeys are disabled in multi-select mode to avoid ambiguity with `Space`.
+
+Disabled items are automatically skipped during navigation, including by `Home` and `End`.
 
 `Escape` calls the `onCancel` prop when provided — useful for multi-step CLI flows that need a "go back" action.
 

--- a/src/enhanced-select-input/index.tsx
+++ b/src/enhanced-select-input/index.tsx
@@ -26,6 +26,23 @@ export type UseEnhancedSelectInputProperties<V> = {
   /** Called when Escape is pressed while the component is focused. */
   readonly onCancel?: () => void
   readonly orientation?: 'vertical' | 'horizontal'
+  /** Enable multi-select mode. Space toggles, Enter confirms. */
+  readonly multiple?: boolean
+  /**
+   * Pre-selected item keys in multi-select mode.
+   * Each entry should match an item's `key` field (or `String(value)` fallback).
+   */
+  readonly defaultSelectedKeys?: string[]
+  /**
+   * Called when the user confirms a multi-select (Enter).
+   * Only used when `multiple` is true.
+   */
+  readonly onConfirm?: (items: Array<Item<V>>) => void
+  /**
+   * Called each time an item is toggled in multi-select mode (Space).
+   * Receives the toggled item and whether it is now checked.
+   */
+  readonly onToggle?: (item: Item<V>, checked: boolean) => void
 }
 
 /** Full component props — hook props plus rendering customisation. */
@@ -42,6 +59,8 @@ export type Properties<V> = UseEnhancedSelectInputProperties<V> & {
 
 export type IndicatorProperties = {
   readonly isSelected: boolean
+  /** True when the item is checked in multi-select mode. Undefined in single-select mode. */
+  readonly isChecked?: boolean
   // eslint-disable-next-line  react/no-unused-prop-types
   readonly item: Item<unknown>
 }
@@ -50,6 +69,8 @@ export type ItemProperties = {
   readonly isSelected: boolean
   readonly label: string
   readonly isDisabled: boolean
+  /** True when the item is checked in multi-select mode. Undefined in single-select mode. */
+  readonly isChecked?: boolean
 }
 
 // Vim navigation keys that take precedence over hotkeys.
@@ -109,6 +130,10 @@ export function findLastValidIndex<V>(items: Array<Item<V>>): number {
   return items.length - 1
 }
 
+function itemKey<V>(item: Item<V>): string {
+  return item.key ?? String(item.value)
+}
+
 export type UseEnhancedSelectInputResult<V> = {
   /** Index of the currently highlighted item within the full items array. */
   selectedIndex: number
@@ -122,6 +147,8 @@ export type UseEnhancedSelectInputResult<V> = {
   itemsAbove: number
   /** Number of items hidden below the current window. */
   itemsBelow: number
+  /** Keys of checked items. Only populated in multi-select mode. */
+  checkedKeys: Set<string>
 }
 
 /**
@@ -138,11 +165,18 @@ export function useEnhancedSelectInput<V>({
   onHighlight,
   onCancel,
   orientation = 'vertical',
+  multiple = false,
+  defaultSelectedKeys,
+  onConfirm,
+  onToggle,
 }: UseEnhancedSelectInputProperties<V>): UseEnhancedSelectInputResult<V> {
   const safeInitialIndex = resolveInitialIndex(items, initialIndex)
   const [selectedIndex, setSelectedIndex] = useState(safeInitialIndex)
   const [rotateIndex, setRotateIndex] = useState(
     limit ? Math.floor(safeInitialIndex / limit) * limit : 0
+  )
+  const [checkedKeys, setCheckedKeys] = useState<Set<string>>(
+    () => new Set(defaultSelectedKeys ?? [])
   )
 
   const hasItems = items.length > 0
@@ -161,7 +195,7 @@ export function useEnhancedSelectInput<V>({
   // String(value) to produce "[object Object]" for every item.
   useEffect(() => {
     if (process.env['NODE_ENV'] !== 'production' && items.length > 0) {
-      const keys = items.map((item) => item.key ?? String(item.value))
+      const keys = items.map((item) => itemKey(item))
       const seen = new Set<string>()
       const duplicates = new Set<string>()
       for (const k of keys) {
@@ -230,6 +264,24 @@ export function useEnhancedSelectInput<V>({
         return
       }
 
+      // Space: toggle in multi-select mode
+      if (multiple && input === ' ') {
+        const item = items[selectedIndex]
+        if (item && !item.disabled) {
+          const k = itemKey(item)
+          setCheckedKeys((prev) => {
+            const next = new Set(prev)
+            const nowChecked = !next.has(k)
+            if (nowChecked) next.add(k)
+            else next.delete(k)
+            onToggle?.(item, nowChecked)
+            return next
+          })
+        }
+
+        return
+      }
+
       let nextIndex = selectedIndex
 
       if (orientation === 'vertical') {
@@ -255,15 +307,21 @@ export function useEnhancedSelectInput<V>({
       }
 
       if (key.return) {
-        const selectedItem = items[selectedIndex]
-        if (selectedItem && !selectedItem.disabled) {
-          onSelect?.(selectedItem)
+        if (multiple) {
+          // In multi-select mode Enter confirms the full selection
+          const confirmed = items.filter((item) => checkedKeys.has(itemKey(item)))
+          onConfirm?.(confirmed)
+        } else {
+          const selectedItem = items[selectedIndex]
+          if (selectedItem && !selectedItem.disabled) {
+            onSelect?.(selectedItem)
+          }
         }
       }
 
       // Hotkeys: nav keys for the active orientation take priority.
-      // See README "Keyboard Navigation" for reserved key constraints.
-      if (!isNavKey) {
+      // Hotkeys are not active in multi-select mode to avoid ambiguity.
+      if (!multiple && !isNavKey) {
         const hotkeyItem = items.find(
           (item) => item.hotkey === input && !item.disabled
         )
@@ -277,10 +335,33 @@ export function useEnhancedSelectInput<V>({
     { isActive: isFocused }
   )
 
-  return { selectedIndex, rotateIndex, visibleItems, hasItems, itemsAbove, itemsBelow }
+  return {
+    selectedIndex,
+    rotateIndex,
+    visibleItems,
+    hasItems,
+    itemsAbove,
+    itemsBelow,
+    checkedKeys,
+  }
 }
 
-export function DefaultIndicatorComponent({ isSelected }: IndicatorProperties) {
+export function DefaultIndicatorComponent({
+  isSelected,
+  isChecked,
+}: IndicatorProperties) {
+  if (isChecked !== undefined) {
+    // Multi-select mode: show checkbox + cursor
+    return (
+      <Box marginRight={1}>
+        <Text color={isSelected ? 'green' : undefined}>
+          {isChecked ? '[x]' : '[ ]'}
+        </Text>
+      </Box>
+    )
+  }
+
+  // Single-select mode: classic arrow cursor
   return (
     <Box marginRight={1}>
       <Text color={isSelected ? 'green' : undefined}>
@@ -312,8 +393,15 @@ export function EnhancedSelectInput<V>({
   // All remaining props are forwarded to the hook
   ...hookProps
 }: Properties<V>) {
-  const { selectedIndex, rotateIndex, visibleItems, hasItems, itemsAbove, itemsBelow } =
-    useEnhancedSelectInput(hookProps)
+  const {
+    selectedIndex,
+    rotateIndex,
+    visibleItems,
+    hasItems,
+    itemsAbove,
+    itemsBelow,
+    checkedKeys,
+  } = useEnhancedSelectInput(hookProps)
 
   if (!hasItems) {
     return <Box />
@@ -322,6 +410,7 @@ export function EnhancedSelectInput<V>({
   const IndicatorComponent = indicatorComponent
   const ItemComponent = itemComponent
   const isVertical = hookProps.orientation !== 'horizontal'
+  const isMultiple = hookProps.multiple === true
 
   return (
     <Box flexDirection={isVertical ? 'column' : 'row'}>
@@ -338,22 +427,30 @@ export function EnhancedSelectInput<V>({
       >
         {visibleItems.map((item, index) => {
           const isSelected = index + rotateIndex === selectedIndex
+          const isChecked = isMultiple
+            ? checkedKeys.has(item.key ?? String(item.value))
+            : undefined
 
           return (
             <Box key={item.key ?? String(item.value)}>
-              {item.indicator ? (
+              {item.indicator && !isMultiple ? (
                 <Box marginRight={1}>
                   <Text>{isSelected ? item.indicator : ' '}</Text>
                 </Box>
               ) : (
-                <IndicatorComponent isSelected={isSelected} item={item} />
+                <IndicatorComponent
+                  isSelected={isSelected}
+                  isChecked={isChecked}
+                  item={item}
+                />
               )}
               <ItemComponent
                 isSelected={isSelected}
                 label={item.label}
                 isDisabled={Boolean(item.disabled)}
+                isChecked={isChecked}
               />
-              {item.hotkey && (
+              {item.hotkey && !isMultiple && (
                 <Text dimColor color="gray">
                   {' '}
                   ({item.hotkey})

--- a/src/test/enhanced-select-input.test.tsx
+++ b/src/test/enhanced-select-input.test.tsx
@@ -18,6 +18,7 @@ const ENTER = '\r'
 const ESCAPE = '\u001B'
 const HOME = '\u001B[H'
 const END = '\u001B[F'
+const SPACE = ' '
 
 // Small delay to let React/Ink process state updates
 const delay = async (ms = 50) =>
@@ -1518,4 +1519,276 @@ test('no duplicate key warning when all items have explicit keys', async (t) => 
   } finally {
     console.warn = originalWarn
   }
+})
+
+// --- Multi-select mode (#12) ---
+
+test('multi-select renders checkbox indicators instead of arrow cursor', (t) => {
+  const items = [
+    { label: 'A', value: 'a' },
+    { label: 'B', value: 'b' },
+    { label: 'C', value: 'c' },
+  ]
+  const { lastFrame } = render(<EnhancedSelectInput items={items} multiple />)
+  const frame = lastFrame()!
+  t.true(frame.includes('[ ]'))
+  t.false(frame.includes('>'))
+})
+
+test('multi-select space toggles checked state on', async (t) => {
+  const items = [
+    { label: 'A', value: 'a' },
+    { label: 'B', value: 'b' },
+  ]
+  const { stdin, lastFrame } = render(<EnhancedSelectInput items={items} multiple />)
+
+  await delay()
+  t.false(lastFrame()!.includes('[x]'))
+
+  stdin.write(SPACE)
+  await delay()
+  t.true(lastFrame()!.includes('[x]'))
+})
+
+test('multi-select space toggles checked state off', async (t) => {
+  const items = [{ label: 'A', value: 'a' }]
+  const { stdin, lastFrame } = render(
+    <EnhancedSelectInput items={items} multiple defaultSelectedKeys={['a']} />
+  )
+
+  await delay()
+  t.true(lastFrame()!.includes('[x]'))
+
+  stdin.write(SPACE)
+  await delay()
+  t.false(lastFrame()!.includes('[x]'))
+})
+
+test('multi-select defaultSelectedKeys pre-checks items', (t) => {
+  const items = [
+    { label: 'A', value: 'a' },
+    { label: 'B', value: 'b' },
+    { label: 'C', value: 'c' },
+  ]
+  const { lastFrame } = render(
+    <EnhancedSelectInput items={items} multiple defaultSelectedKeys={['a', 'c']} />
+  )
+  const frame = lastFrame()!
+  t.is((frame.match(/\[x\]/g) ?? []).length, 2)
+  t.is((frame.match(/\[ \]/g) ?? []).length, 1)
+})
+
+test('multi-select enter calls onConfirm with checked items', async (t) => {
+  const items = [
+    { label: 'A', value: 'a' },
+    { label: 'B', value: 'b' },
+    { label: 'C', value: 'c' },
+  ]
+
+  let confirmed: string[] = []
+  const { stdin } = render(
+    <EnhancedSelectInput
+      items={items}
+      multiple
+      onConfirm={(selected) => {
+        confirmed = selected.map((item) => String(item.value))
+      }}
+    />
+  )
+
+  await delay()
+  stdin.write(SPACE) // check A
+  await delay()
+  stdin.write(ARROW_DOWN) // → B
+  await delay()
+  stdin.write(ARROW_DOWN) // → C
+  await delay()
+  stdin.write(SPACE) // check C
+  await delay()
+  stdin.write(ENTER)
+  await delay()
+
+  t.is(confirmed.length, 2)
+  t.true(confirmed.includes('a'))
+  t.true(confirmed.includes('c'))
+})
+
+test('multi-select enter with nothing checked calls onConfirm with empty array', async (t) => {
+  const items = [
+    { label: 'A', value: 'a' },
+    { label: 'B', value: 'b' },
+  ]
+
+  let confirmed: unknown[] | null = null
+  const { stdin } = render(
+    <EnhancedSelectInput
+      items={items}
+      multiple
+      onConfirm={(selected) => {
+        confirmed = selected
+      }}
+    />
+  )
+
+  await delay()
+  stdin.write(ENTER)
+  await delay()
+
+  t.not(confirmed, null)
+  t.is(confirmed!.length, 0)
+})
+
+test('multi-select onToggle fires with item and checked state', async (t) => {
+  const items = [{ label: 'A', value: 'a' }]
+
+  const log: Array<{ label: string; checked: boolean }> = []
+  const { stdin } = render(
+    <EnhancedSelectInput
+      items={items}
+      multiple
+      onToggle={(item, checked) => {
+        log.push({ label: item.label, checked })
+      }}
+    />
+  )
+
+  await delay()
+  stdin.write(SPACE)
+  await delay()
+  t.is(log.length, 1)
+  t.is(log[0]?.label, 'A')
+  t.is(log[0]?.checked, true)
+
+  stdin.write(SPACE)
+  await delay()
+  t.is(log.length, 2)
+  t.is(log[1]?.checked, false)
+})
+
+test('multi-select space only toggles enabled items', async (t) => {
+  const items = [
+    { label: 'A', value: 'a' },
+    { label: 'B', value: 'b', disabled: true },
+    { label: 'C', value: 'c' },
+  ]
+
+  const toggled: string[] = []
+  const { stdin } = render(
+    <EnhancedSelectInput
+      items={items}
+      multiple
+      onToggle={(item) => {
+        toggled.push(item.label)
+      }}
+    />
+  )
+
+  await delay()
+  stdin.write(SPACE) // toggle A
+  await delay()
+  stdin.write(ARROW_DOWN) // skip B → land on C
+  await delay()
+  stdin.write(SPACE) // toggle C
+  await delay()
+
+  t.is(toggled.length, 2)
+  t.true(toggled.includes('A'))
+  t.true(toggled.includes('C'))
+  t.false(toggled.includes('B'))
+})
+
+test('multi-select hotkeys do not fire in multi-select mode', async (t) => {
+  const items = [
+    { label: 'A', value: 'a', hotkey: 'x' },
+    { label: 'B', value: 'b', hotkey: 'y' },
+  ]
+
+  let selected = ''
+  const { stdin } = render(
+    <EnhancedSelectInput
+      items={items}
+      multiple
+      onSelect={(item) => {
+        selected = item.label
+      }}
+    />
+  )
+
+  await delay()
+  stdin.write('x')
+  await delay()
+  t.is(selected, '')
+})
+
+test('multi-select hotkey hints not shown in render', (t) => {
+  const items = [
+    { label: 'A', value: 'a', hotkey: 'x' },
+    { label: 'B', value: 'b', hotkey: 'y' },
+  ]
+
+  const { lastFrame } = render(<EnhancedSelectInput items={items} multiple />)
+  const frame = lastFrame()!
+  t.false(frame.includes('(x)'))
+  t.false(frame.includes('(y)'))
+})
+
+test('multi-select isChecked passed to custom indicatorComponent', async (t) => {
+  const items = [{ label: 'A', value: 'a' }]
+
+  let receivedIsChecked: boolean | undefined
+  const { stdin } = render(
+    <EnhancedSelectInput
+      items={items}
+      multiple
+      indicatorComponent={({ isChecked }) => {
+        receivedIsChecked = isChecked
+        return null
+      }}
+    />
+  )
+
+  await delay()
+  t.is(receivedIsChecked, false)
+
+  stdin.write(SPACE)
+  await delay()
+  t.is(receivedIsChecked, true)
+})
+
+test('multi-select isChecked passed to custom itemComponent', async (t) => {
+  const items = [{ label: 'A', value: 'a' }]
+
+  let receivedIsChecked: boolean | undefined
+  const { stdin } = render(
+    <EnhancedSelectInput
+      items={items}
+      multiple
+      itemComponent={({ isChecked }) => {
+        receivedIsChecked = isChecked
+        return null
+      }}
+    />
+  )
+
+  await delay()
+  t.is(receivedIsChecked, false)
+
+  stdin.write(SPACE)
+  await delay()
+  t.is(receivedIsChecked, true)
+})
+
+test('DefaultIndicatorComponent renders checkboxes in multi-select mode', (t) => {
+  const item = { label: 'X', value: 'x' }
+
+  const { lastFrame: checkedFrame } = render(
+    <DefaultIndicatorComponent isSelected item={item} isChecked />
+  )
+  const { lastFrame: uncheckedFrame } = render(
+    <DefaultIndicatorComponent isSelected={false} item={item} isChecked={false} />
+  )
+
+  t.true(checkedFrame()!.includes('[x]'))
+  t.true(uncheckedFrame()!.includes('[ ]'))
+  t.false(checkedFrame()!.includes('>'))
 })


### PR DESCRIPTION
## Summary

- Adds `multiple` prop to enable multi-select mode: Space toggles, Enter confirms
- `defaultSelectedKeys` pre-populates checked state from a list of item keys
- `onConfirm(items)` called on Enter with all currently checked items
- `onToggle(item, checked)` called on each individual Space toggle
- `DefaultIndicatorComponent` renders `[x]`/`[ ]` checkboxes when `isChecked` is provided
- `isChecked` threaded through to custom `indicatorComponent` and `itemComponent`
- Hotkeys and per-item hotkey hints disabled in multi-select mode to avoid `Space` ambiguity
- `useEnhancedSelectInput` hook exposes `checkedKeys: Set<string>` for headless usage
- 13 new tests; 68 total passing

Closes #12

## Test plan

- [x] `multi-select renders checkbox indicators instead of arrow cursor`
- [x] `multi-select space toggles checked state on/off`
- [x] `multi-select defaultSelectedKeys pre-checks items`
- [x] `multi-select enter calls onConfirm with checked items`
- [x] `multi-select enter with nothing checked calls onConfirm with empty array`
- [x] `multi-select onToggle fires with item and checked state`
- [x] `multi-select space only toggles enabled items`
- [x] `multi-select hotkeys do not fire in multi-select mode`
- [x] `multi-select hotkey hints not shown in render`
- [x] `multi-select isChecked passed to custom indicatorComponent`
- [x] `multi-select isChecked passed to custom itemComponent`
- [x] `DefaultIndicatorComponent renders checkboxes in multi-select mode`

🤖 Generated with [Claude Code](https://claude.com/claude-code)