### PR TITLE
feat: item group support with section headers

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,43 +4,43 @@
 
 ### 🌟 New Features
 
-* add multi-select mode ([#12](https://github.com/gfargo/ink-enhanced-select-input/issues/12)) ([#24](https://github.com/gfargo/ink-enhanced-select-input/issues/24)) ([aca72bb](https://github.com/gfargo/ink-enhanced-select-input/commit/aca72bbbce5c25fcdaa1190fd919f2eb9d5ee85d))
+- add multi-select mode ([#12](https://github.com/gfargo/ink-enhanced-select-input/issues/12)) ([#24](https://github.com/gfargo/ink-enhanced-select-input/issues/24)) ([aca72bb](https://github.com/gfargo/ink-enhanced-select-input/commit/aca72bbbce5c25fcdaa1190fd919f2eb9d5ee85d))
 
 ### 🐞 Bug Fixes
 
-* rename release config file ([d192ec4](https://github.com/gfargo/ink-enhanced-select-input/commit/d192ec4550837f772bb6a54271d0c5d8525bb15f))
-* warn in development when duplicate item keys are detected ([#16](https://github.com/gfargo/ink-enhanced-select-input/issues/16)) ([#23](https://github.com/gfargo/ink-enhanced-select-input/issues/23)) ([29dcacd](https://github.com/gfargo/ink-enhanced-select-input/commit/29dcacdd31c35a1ecf43a68eec01936ca2fe4cf6))
+- rename release config file ([d192ec4](https://github.com/gfargo/ink-enhanced-select-input/commit/d192ec4550837f772bb6a54271d0c5d8525bb15f))
+- warn in development when duplicate item keys are detected ([#16](https://github.com/gfargo/ink-enhanced-select-input/issues/16)) ([#23](https://github.com/gfargo/ink-enhanced-select-input/issues/23)) ([29dcacd](https://github.com/gfargo/ink-enhanced-select-input/commit/29dcacdd31c35a1ecf43a68eec01936ca2fe4cf6))
 
 ## [0.5.0](https://github.com/gfargo/ink-enhanced-select-input/compare/0.4.0...0.5.0) (2026-05-05)
 
 ### 🌟 New Features
 
-* add showScrollIndicators prop for paginated lists ([#9](https://github.com/gfargo/ink-enhanced-select-input/issues/9)) ([#20](https://github.com/gfargo/ink-enhanced-select-input/issues/20)) ([4557707](https://github.com/gfargo/ink-enhanced-select-input/commit/4557707ccadeb0fc50523883f43acdec22596a4e))
-* extract useEnhancedSelectInput headless hook ([#8](https://github.com/gfargo/ink-enhanced-select-input/issues/8)) ([#21](https://github.com/gfargo/ink-enhanced-select-input/issues/21)) ([7c1e0a1](https://github.com/gfargo/ink-enhanced-select-input/commit/7c1e0a1a3785a04fd394fc26da45148dc1789648))
-* onCancel/Escape, Home/End keys, and bug fixes ([#19](https://github.com/gfargo/ink-enhanced-select-input/issues/19)) ([d459214](https://github.com/gfargo/ink-enhanced-select-input/commit/d45921417dc3593b91a6f612a05d811e21a545c8)), closes [#10](https://github.com/gfargo/ink-enhanced-select-input/issues/10) [#11](https://github.com/gfargo/ink-enhanced-select-input/issues/11) [#16](https://github.com/gfargo/ink-enhanced-select-input/issues/16) [#17](https://github.com/gfargo/ink-enhanced-select-input/issues/17)
+- add showScrollIndicators prop for paginated lists ([#9](https://github.com/gfargo/ink-enhanced-select-input/issues/9)) ([#20](https://github.com/gfargo/ink-enhanced-select-input/issues/20)) ([4557707](https://github.com/gfargo/ink-enhanced-select-input/commit/4557707ccadeb0fc50523883f43acdec22596a4e))
+- extract useEnhancedSelectInput headless hook ([#8](https://github.com/gfargo/ink-enhanced-select-input/issues/8)) ([#21](https://github.com/gfargo/ink-enhanced-select-input/issues/21)) ([7c1e0a1](https://github.com/gfargo/ink-enhanced-select-input/commit/7c1e0a1a3785a04fd394fc26da45148dc1789648))
+- onCancel/Escape, Home/End keys, and bug fixes ([#19](https://github.com/gfargo/ink-enhanced-select-input/issues/19)) ([d459214](https://github.com/gfargo/ink-enhanced-select-input/commit/d45921417dc3593b91a6f612a05d811e21a545c8)), closes [#10](https://github.com/gfargo/ink-enhanced-select-input/issues/10) [#11](https://github.com/gfargo/ink-enhanced-select-input/issues/11) [#16](https://github.com/gfargo/ink-enhanced-select-input/issues/16) [#17](https://github.com/gfargo/ink-enhanced-select-input/issues/17)
 
 ### 🐞 Bug Fixes
 
-* audit improvements — bugs, exports, and test coverage ([#18](https://github.com/gfargo/ink-enhanced-select-input/issues/18)) ([bc75b17](https://github.com/gfargo/ink-enhanced-select-input/commit/bc75b17d71444d6ecea050c843cdfdb74416552d))
-* re-sync selection when items prop changes after mount ([#15](https://github.com/gfargo/ink-enhanced-select-input/issues/15)) ([#22](https://github.com/gfargo/ink-enhanced-select-input/issues/22)) ([89dfcb1](https://github.com/gfargo/ink-enhanced-select-input/commit/89dfcb1d61286b418782dfdbbfcf6710fec47ce8))
+- audit improvements — bugs, exports, and test coverage ([#18](https://github.com/gfargo/ink-enhanced-select-input/issues/18)) ([bc75b17](https://github.com/gfargo/ink-enhanced-select-input/commit/bc75b17d71444d6ecea050c843cdfdb74416552d))
+- re-sync selection when items prop changes after mount ([#15](https://github.com/gfargo/ink-enhanced-select-input/issues/15)) ([#22](https://github.com/gfargo/ink-enhanced-select-input/issues/22)) ([89dfcb1](https://github.com/gfargo/ink-enhanced-select-input/commit/89dfcb1d61286b418782dfdbbfcf6710fec47ce8))
 
 ## [0.4.0](https://github.com/gfargo/ink-enhanced-select-input/compare/0.3.0...0.4.0) (2026-03-24)
 
 ### 🐞 Bug Fixes
 
-* limit prop now paginates — all items reachable via navigation ([e4d243f](https://github.com/gfargo/ink-enhanced-select-input/commit/e4d243f6c7249a2fa02b1e6b10d251ae73f957ca)), closes [#5](https://github.com/gfargo/ink-enhanced-select-input/issues/5)
-* resolve lint and formatting issues ([acd5747](https://github.com/gfargo/ink-enhanced-select-input/commit/acd574763f0954bd7717c1b9caf59fa37eaef116))
-* skip disabled items when resolving initialIndex ([4defb10](https://github.com/gfargo/ink-enhanced-select-input/commit/4defb10cd1a7d444093d547d550f20514b9302d9)), closes [#4](https://github.com/gfargo/ink-enhanced-select-input/issues/4)
+- limit prop now paginates — all items reachable via navigation ([e4d243f](https://github.com/gfargo/ink-enhanced-select-input/commit/e4d243f6c7249a2fa02b1e6b10d251ae73f957ca)), closes [#5](https://github.com/gfargo/ink-enhanced-select-input/issues/5)
+- resolve lint and formatting issues ([acd5747](https://github.com/gfargo/ink-enhanced-select-input/commit/acd574763f0954bd7717c1b9caf59fa37eaef116))
+- skip disabled items when resolving initialIndex ([4defb10](https://github.com/gfargo/ink-enhanced-select-input/commit/4defb10cd1a7d444093d547d550f20514b9302d9)), closes [#4](https://github.com/gfargo/ink-enhanced-select-input/issues/4)
 
 ### ✅ Tests
 
-* remove snapshot assertions for CI compatibility ([051f5c8](https://github.com/gfargo/ink-enhanced-select-input/commit/051f5c8452fa4eba31b8be0cee2706b30286967f))
+- remove snapshot assertions for CI compatibility ([051f5c8](https://github.com/gfargo/ink-enhanced-select-input/commit/051f5c8452fa4eba31b8be0cee2706b30286967f))
 
 ## [0.3.0](https://github.com/gfargo/ink-enhanced-select-input/compare/0.2.0...0.3.0) (2026-03-21)
 
 ### 📝 Documentation
 
-* **readme:** update compatibility and usage info ([5f9814a](https://github.com/gfargo/ink-enhanced-select-input/commit/5f9814ae9669f89135988d122f5bcbc6e98f1917))
+- **readme:** update compatibility and usage info ([5f9814a](https://github.com/gfargo/ink-enhanced-select-input/commit/5f9814ae9669f89135988d122f5bcbc6e98f1917))
 
 ## [0.2.0](https://github.com/gfargo/ink-enhanced-select-input/compare/0.1.2...0.2.0) (2025-01-02)
 

--- a/readme.md
+++ b/readme.md
@@ -104,7 +104,10 @@ function MultiDemo() {
         console.log(`${item.label} is now ${checked ? 'checked' : 'unchecked'}`)
       }
       onConfirm={(selected) =>
-        console.log('Confirmed:', selected.map((i) => i.value))
+        console.log(
+          'Confirmed:',
+          selected.map((i) => i.value)
+        )
       }
     />
   )
@@ -123,6 +126,46 @@ render(<MultiDemo />)
     { label: 'Cancel', value: 'cancel', hotkey: 'c' },
   ]}
   onSelect={(item) => console.log(item.value)}
+/>
+```
+
+### Grouped Items
+
+Group items under section headers by setting the `group` field. Items sharing the same `group` value are visually grouped, and a header row is rendered before the first item in each group. Headers are purely visual — they are non-navigable and do not affect selection.
+
+```tsx
+<EnhancedSelectInput
+  items={[
+    { label: 'Option A', value: 'a', group: 'Recent' },
+    { label: 'Option B', value: 'b', group: 'Recent' },
+    { label: 'Option C', value: 'c', group: 'All' },
+    { label: 'Option D', value: 'd', group: 'All' },
+  ]}
+  onSelect={(item) => console.log(item.value)}
+/>
+```
+
+Renders:
+
+```
+── Recent ──
+> Option A
+  Option B
+── All ──
+  Option C
+  Option D
+```
+
+You can provide a custom header renderer via `groupHeaderComponent`:
+
+```tsx
+<EnhancedSelectInput
+  items={items}
+  groupHeaderComponent={({ label }) => (
+    <Text bold color="cyan">
+      {label}
+    </Text>
+  )}
 />
 ```
 
@@ -170,7 +213,10 @@ function MyCustomSelect({ items, onSelect }) {
     <Box flexDirection="column">
       {itemsAbove > 0 && <Text dimColor>↑ {itemsAbove} more</Text>}
       {visibleItems.map((item, i) => (
-        <Text key={item.key ?? String(item.value)} color={i === selectedIndex ? 'cyan' : undefined}>
+        <Text
+          key={item.key ?? String(item.value)}
+          color={i === selectedIndex ? 'cyan' : undefined}
+        >
           {item.label}
         </Text>
       ))}
@@ -180,38 +226,40 @@ function MyCustomSelect({ items, onSelect }) {
 }
 ```
 
-The hook accepts all the same props as `EnhancedSelectInput` except `indicatorComponent`, `itemComponent`, and `showScrollIndicators`. It returns `{ selectedIndex, rotateIndex, visibleItems, hasItems, itemsAbove, itemsBelow, checkedKeys }`. `checkedKeys` is a `Set<string>` of checked item keys — only populated when `multiple` is `true`.
+The hook accepts all the same props as `EnhancedSelectInput` except `indicatorComponent`, `itemComponent`, `groupHeaderComponent`, and `showScrollIndicators`. It returns `{ selectedIndex, rotateIndex, visibleItems, hasItems, itemsAbove, itemsBelow, checkedKeys }`. `checkedKeys` is a `Set<string>` of checked item keys — only populated when `multiple` is `true`.
 
 ## Props
 
-| Prop                   | Type                              | Default                     | Description                              |
-| ---------------------- | --------------------------------- | --------------------------- | ---------------------------------------- |
-| `items`                | `Array<Item<V>>`                  | _required_                  | List of selectable items                 |
-| `isFocused`            | `boolean`                         | `true`                      | Whether the component responds to input  |
-| `initialIndex`         | `number`                          | `0`                         | Index of the initially highlighted item  |
-| `limit`                | `number`                          | —                           | Max number of visible items              |
-| `indicatorComponent`   | `FC<IndicatorProps>`              | `DefaultIndicatorComponent` | Custom selection indicator               |
-| `itemComponent`        | `FC<ItemProps>`                   | `DefaultItemComponent`      | Custom item renderer                     |
-| `onSelect`             | `(item: Item<V>) => void`         | —                           | Called on selection (Enter or hotkey) — single-select only |
-| `onHighlight`          | `(item: Item<V>) => void`         | —                           | Called when the highlighted item changes |
-| `onCancel`             | `() => void`                      | —                           | Called when Escape is pressed            |
-| `orientation`          | `'vertical' \| 'horizontal'`      | `'vertical'`                | Layout direction                         |
-| `showScrollIndicators` | `boolean`                         | `false`                     | Show ▲/▼ or ◀/▶ counts when `limit` clips the list |
-| `multiple`             | `boolean`                         | `false`                     | Enable multi-select mode (Space toggles, Enter confirms) |
-| `defaultSelectedKeys`  | `string[]`                        | —                           | Pre-checked item keys for multi-select   |
-| `onConfirm`            | `(items: Array<Item<V>>) => void` | —                           | Called on Enter in multi-select mode with all checked items |
-| `onToggle`             | `(item: Item<V>, checked: boolean) => void` | —             | Called each time an item is toggled in multi-select mode |
+| Prop                   | Type                                        | Default                       | Description                                                 |
+| ---------------------- | ------------------------------------------- | ----------------------------- | ----------------------------------------------------------- |
+| `items`                | `Array<Item<V>>`                            | _required_                    | List of selectable items                                    |
+| `isFocused`            | `boolean`                                   | `true`                        | Whether the component responds to input                     |
+| `initialIndex`         | `number`                                    | `0`                           | Index of the initially highlighted item                     |
+| `limit`                | `number`                                    | —                             | Max number of visible items                                 |
+| `indicatorComponent`   | `FC<IndicatorProps>`                        | `DefaultIndicatorComponent`   | Custom selection indicator                                  |
+| `itemComponent`        | `FC<ItemProps>`                             | `DefaultItemComponent`        | Custom item renderer                                        |
+| `onSelect`             | `(item: Item<V>) => void`                   | —                             | Called on selection (Enter or hotkey) — single-select only  |
+| `onHighlight`          | `(item: Item<V>) => void`                   | —                             | Called when the highlighted item changes                    |
+| `onCancel`             | `() => void`                                | —                             | Called when Escape is pressed                               |
+| `orientation`          | `'vertical' \| 'horizontal'`                | `'vertical'`                  | Layout direction                                            |
+| `showScrollIndicators` | `boolean`                                   | `false`                       | Show ▲/▼ or ◀/▶ counts when `limit` clips the list          |
+| `multiple`             | `boolean`                                   | `false`                       | Enable multi-select mode (Space toggles, Enter confirms)    |
+| `defaultSelectedKeys`  | `string[]`                                  | —                             | Pre-checked item keys for multi-select                      |
+| `onConfirm`            | `(items: Array<Item<V>>) => void`           | —                             | Called on Enter in multi-select mode with all checked items |
+| `onToggle`             | `(item: Item<V>, checked: boolean) => void` | —                             | Called each time an item is toggled in multi-select mode    |
+| `groupHeaderComponent` | `FC<GroupHeaderProps>`                      | `DefaultGroupHeaderComponent` | Custom group header renderer                                |
 
 ### Item Shape
 
 ```ts
 type Item<V> = {
-  key?: string        // Required when V is an object — see note below
+  key?: string // Required when V is an object — see note below
   label: string
   value: V
   hotkey?: string
   indicator?: React.ReactNode
   disabled?: boolean
+  group?: string // Items with the same group are rendered under a shared header
 }
 ```
 
@@ -223,10 +271,10 @@ type Item<V> = {
 
 ## Keyboard Navigation
 
-| Orientation | Previous  | Next      | First    | Last    | Select / Confirm | Toggle (multi) | Cancel   |
-| ----------- | --------- | --------- | -------- | ------- | ---------------- | -------------- | -------- |
-| Vertical    | `↑` / `k` | `↓` / `j` | `Home`   | `End`   | `Enter`          | `Space`        | `Escape` |
-| Horizontal  | `←` / `h` | `→` / `l` | `Home`   | `End`   | `Enter`          | `Space`        | `Escape` |
+| Orientation | Previous  | Next      | First  | Last  | Select / Confirm | Toggle (multi) | Cancel   |
+| ----------- | --------- | --------- | ------ | ----- | ---------------- | -------------- | -------- |
+| Vertical    | `↑` / `k` | `↓` / `j` | `Home` | `End` | `Enter`          | `Space`        | `Escape` |
+| Horizontal  | `←` / `h` | `→` / `l` | `Home` | `End` | `Enter`          | `Space`        | `Escape` |
 
 In **single-select** mode, `Enter` calls `onSelect` and hotkeys select immediately. In **multi-select** mode (`multiple={true}`), `Space` toggles the highlighted item and `Enter` calls `onConfirm` with all checked items. Hotkeys are disabled in multi-select mode to avoid ambiguity with `Space`.
 

--- a/src/enhanced-select-input/index.tsx
+++ b/src/enhanced-select-input/index.tsx
@@ -13,6 +13,11 @@ export type Item<V> = {
   hotkey?: string
   indicator?: React.ReactNode
   disabled?: boolean
+  /**
+   * Group name for this item. Items sharing the same group value are visually
+   * grouped under a header row. Headers are non-navigable.
+   */
+  group?: string
 }
 
 /** Props accepted by the useEnhancedSelectInput hook (all behaviour, no rendering). */
@@ -49,11 +54,13 @@ export type UseEnhancedSelectInputProperties<V> = {
 export type Properties<V> = UseEnhancedSelectInputProperties<V> & {
   readonly indicatorComponent?: FC<IndicatorProperties>
   readonly itemComponent?: FC<ItemProperties>
+  readonly groupHeaderComponent?: FC<GroupHeaderProperties>
   /**
    * Show ▲/▼ (vertical) or ◀/▶ (horizontal) indicators with item counts
    * when the limit window doesn't cover the full list. Only meaningful when
    * `limit` is set. Defaults to false.
    */
+  // eslint-disable-next-line react/boolean-prop-naming
   readonly showScrollIndicators?: boolean
 }
 
@@ -61,7 +68,7 @@ export type IndicatorProperties = {
   readonly isSelected: boolean
   /** True when the item is checked in multi-select mode. Undefined in single-select mode. */
   readonly isChecked?: boolean
-  // eslint-disable-next-line  react/no-unused-prop-types
+  // eslint-disable-next-line react/no-unused-prop-types
   readonly item: Item<unknown>
 }
 
@@ -70,7 +77,12 @@ export type ItemProperties = {
   readonly label: string
   readonly isDisabled: boolean
   /** True when the item is checked in multi-select mode. Undefined in single-select mode. */
+  // eslint-disable-next-line react/no-unused-prop-types
   readonly isChecked?: boolean
+}
+
+export type GroupHeaderProperties = {
+  readonly label: string
 }
 
 // Vim navigation keys that take precedence over hotkeys.
@@ -115,8 +127,8 @@ export function findNextValidIndex<V>(
 }
 
 export function findFirstValidIndex<V>(items: Array<Item<V>>): number {
-  for (let i = 0; i < items.length; i++) {
-    if (!items[i]?.disabled) return i
+  for (const [i, item] of items.entries()) {
+    if (!item?.disabled) return i
   }
 
   return 0
@@ -194,6 +206,7 @@ export function useEnhancedSelectInput<V>({
   // this happens when V is an object and item.key is not set, causing
   // String(value) to produce "[object Object]" for every item.
   useEffect(() => {
+    // eslint-disable-next-line n/prefer-global/process
     if (process.env['NODE_ENV'] !== 'production' && items.length > 0) {
       const keys = items.map((item) => itemKey(item))
       const seen = new Set<string>()
@@ -205,7 +218,9 @@ export function useEnhancedSelectInput<V>({
 
       if (duplicates.size > 0) {
         console.warn(
-          `[ink-enhanced-select-input] Duplicate item keys detected: ${[...duplicates].join(', ')}. ` +
+          `[ink-enhanced-select-input] Duplicate item keys detected: ${[
+            ...duplicates,
+          ].join(', ')}. ` +
             'Set a unique "key" on each item — this is required when value is a non-primitive type (e.g. object).'
         )
       }
@@ -242,11 +257,14 @@ export function useEnhancedSelectInput<V>({
   }
 
   useInput(
+    // eslint-disable-next-line complexity
     (input, key) => {
       if (!hasItems) return
 
+      // eslint-disable-next-line unicorn/prevent-abbreviations
       const navKeys =
         orientation === 'vertical' ? VERTICAL_NAV_KEYS : HORIZONTAL_NAV_KEYS
+      // eslint-disable-next-line unicorn/prevent-abbreviations
       const isNavKey = navKeys.has(input)
 
       if (key.home) {
@@ -269,8 +287,8 @@ export function useEnhancedSelectInput<V>({
         const item = items[selectedIndex]
         if (item && !item.disabled) {
           const k = itemKey(item)
-          setCheckedKeys((prev) => {
-            const next = new Set(prev)
+          setCheckedKeys((previous) => {
+            const next = new Set(previous)
             const nowChecked = !next.has(k)
             if (nowChecked) next.add(k)
             else next.delete(k)
@@ -309,7 +327,9 @@ export function useEnhancedSelectInput<V>({
       if (key.return) {
         if (multiple) {
           // In multi-select mode Enter confirms the full selection
-          const confirmed = items.filter((item) => checkedKeys.has(itemKey(item)))
+          const confirmed = items.filter((item) =>
+            checkedKeys.has(itemKey(item))
+          )
           onConfirm?.(confirmed)
         } else {
           const selectedItem = items[selectedIndex]
@@ -386,12 +406,21 @@ export function DefaultItemComponent({
   )
 }
 
+export function DefaultGroupHeaderComponent({ label }: GroupHeaderProperties) {
+  return (
+    <Box>
+      <Text dimColor>{`── ${label} ──`}</Text>
+    </Box>
+  )
+}
+
 export function EnhancedSelectInput<V>({
   indicatorComponent = DefaultIndicatorComponent,
   itemComponent = DefaultItemComponent,
+  groupHeaderComponent = DefaultGroupHeaderComponent,
   showScrollIndicators = false,
   // All remaining props are forwarded to the hook
-  ...hookProps
+  ...hookProperties
 }: Properties<V>) {
   const {
     selectedIndex,
@@ -401,7 +430,7 @@ export function EnhancedSelectInput<V>({
     itemsAbove,
     itemsBelow,
     checkedKeys,
-  } = useEnhancedSelectInput(hookProps)
+  } = useEnhancedSelectInput(hookProperties)
 
   if (!hasItems) {
     return <Box />
@@ -409,8 +438,12 @@ export function EnhancedSelectInput<V>({
 
   const IndicatorComponent = indicatorComponent
   const ItemComponent = itemComponent
-  const isVertical = hookProps.orientation !== 'horizontal'
-  const isMultiple = hookProps.multiple === true
+  const GroupHeaderComponent = groupHeaderComponent
+  const isVertical = hookProperties.orientation !== 'horizontal'
+  const isMultiple = hookProperties.multiple === true
+
+  // Track which groups have already rendered a header in this window.
+  const renderedGroups = new Set<string>()
 
   return (
     <Box flexDirection={isVertical ? 'column' : 'row'}>
@@ -431,32 +464,47 @@ export function EnhancedSelectInput<V>({
             ? checkedKeys.has(item.key ?? String(item.value))
             : undefined
 
-          return (
-            <Box key={item.key ?? String(item.value)}>
-              {item.indicator && !isMultiple ? (
-                <Box marginRight={1}>
-                  <Text>{isSelected ? item.indicator : ' '}</Text>
-                </Box>
-              ) : (
-                <IndicatorComponent
-                  isSelected={isSelected}
-                  isChecked={isChecked}
-                  item={item}
-                />
-              )}
-              <ItemComponent
-                isSelected={isSelected}
-                label={item.label}
-                isDisabled={Boolean(item.disabled)}
-                isChecked={isChecked}
+          // Determine if we need to render a group header before this item.
+          let groupHeader: React.ReactNode = null
+          if (item.group && !renderedGroups.has(item.group)) {
+            renderedGroups.add(item.group)
+            groupHeader = (
+              <GroupHeaderComponent
+                key={`group-header-${item.group}`}
+                label={item.group}
               />
-              {item.hotkey && !isMultiple && (
-                <Text dimColor color="gray">
-                  {' '}
-                  ({item.hotkey})
-                </Text>
-              )}
-            </Box>
+            )
+          }
+
+          return (
+            <React.Fragment key={item.key ?? String(item.value)}>
+              {groupHeader}
+              <Box>
+                {item.indicator && !isMultiple ? (
+                  <Box marginRight={1}>
+                    <Text>{isSelected ? item.indicator : ' '}</Text>
+                  </Box>
+                ) : (
+                  <IndicatorComponent
+                    isSelected={isSelected}
+                    isChecked={isChecked}
+                    item={item}
+                  />
+                )}
+                <ItemComponent
+                  isSelected={isSelected}
+                  label={item.label}
+                  isDisabled={Boolean(item.disabled)}
+                  isChecked={isChecked}
+                />
+                {item.hotkey && !isMultiple && (
+                  <Text dimColor color="gray">
+                    {' '}
+                    ({item.hotkey})
+                  </Text>
+                )}
+              </Box>
+            </React.Fragment>
           )
         })}
       </Box>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,6 +3,7 @@ export {
   useEnhancedSelectInput,
   DefaultIndicatorComponent,
   DefaultItemComponent,
+  DefaultGroupHeaderComponent,
   resolveInitialIndex,
   findNextValidIndex,
   findFirstValidIndex,
@@ -16,4 +17,5 @@ export type {
   UseEnhancedSelectInputResult,
   IndicatorProperties,
   ItemProperties,
+  GroupHeaderProperties,
 } from './enhanced-select-input/index.js'

--- a/src/test/enhanced-select-input.test.tsx
+++ b/src/test/enhanced-select-input.test.tsx
@@ -3,11 +3,13 @@ import { Box, Text } from 'ink'
 import { render } from 'ink-testing-library'
 import React from 'react'
 import {
+  DefaultGroupHeaderComponent,
   DefaultIndicatorComponent,
   EnhancedSelectInput,
   useEnhancedSelectInput,
+  type Item,
+  type UseEnhancedSelectInputResult,
 } from '../enhanced-select-input/index.js'
-import type { UseEnhancedSelectInputResult } from '../enhanced-select-input/index.js'
 
 // ANSI escape sequences for arrow keys
 const ARROW_UP = '\u001B[A'
@@ -21,7 +23,7 @@ const END = '\u001B[F'
 const SPACE = ' '
 
 // Small delay to let React/Ink process state updates
-const delay = async (ms = 50) =>
+const delay = async (ms = 100) =>
   new Promise<void>((resolve) => {
     setTimeout(resolve, ms)
   })
@@ -818,7 +820,7 @@ test('enter on a disabled item does not trigger onSelect', async (t) => {
   )
 
   await delay()
-  // initialIndex=0 is disabled, so it skips to B (index 1)
+  // InitialIndex=0 is disabled, so it skips to B (index 1)
   // Navigate back to A's slot by going up (wraps to B since A disabled)
   // We can't actually land on A because navigation skips disabled items.
   // Verify that pressing Enter on the current selection (B) works normally.
@@ -859,7 +861,7 @@ test('vim nav key takes priority over matching hotkey', async (t) => {
   stdin.write('j')
   await delay()
   t.is(highlighted, 'B')
-  t.is(selected, '') // hotkey must not have fired
+  t.is(selected, '') // Hotkey must not have fired
 })
 
 // --- DefaultIndicatorComponent in isolation ---
@@ -1154,7 +1156,7 @@ test('showScrollIndicators shows below indicator when items are clipped', (t) =>
   ]
 
   const { lastFrame } = render(
-    <EnhancedSelectInput items={items} limit={2} showScrollIndicators />
+    <EnhancedSelectInput showScrollIndicators items={items} limit={2} />
   )
 
   const frame = lastFrame()!
@@ -1176,9 +1178,9 @@ test('showScrollIndicators shows both indicators when window is mid-list', async
 
   const { stdin, lastFrame } = render(
     <EnhancedSelectInput
+      showScrollIndicators
       items={items}
       limit={2}
-      showScrollIndicators
       initialIndex={2}
     />
   )
@@ -1206,9 +1208,7 @@ test('showScrollIndicators hidden by default', (t) => {
     { label: 'C', value: 'c' },
   ]
 
-  const { lastFrame } = render(
-    <EnhancedSelectInput items={items} limit={2} />
-  )
+  const { lastFrame } = render(<EnhancedSelectInput items={items} limit={2} />)
 
   const frame = lastFrame()!
   t.false(frame.includes('▲'))
@@ -1222,7 +1222,7 @@ test('showScrollIndicators not shown when all items fit in window', (t) => {
   ]
 
   const { lastFrame } = render(
-    <EnhancedSelectInput items={items} limit={5} showScrollIndicators />
+    <EnhancedSelectInput showScrollIndicators items={items} limit={5} />
   )
 
   const frame = lastFrame()!
@@ -1234,18 +1234,18 @@ test('showScrollIndicators not shown when all items fit in window', (t) => {
 
 // HookHarness renders nothing but calls the hook and forwards the result.
 // Value type is unknown since tests only assert on index/count fields.
-type HookHarnessProps = {
-  items: Array<import('../enhanced-select-input/index.js').Item<unknown>>
-  initialIndex?: number
-  limit?: number
-  isFocused?: boolean
-  orientation?: 'vertical' | 'horizontal'
-  onResult: (result: UseEnhancedSelectInputResult<unknown>) => void
+type HookHarnessProperties = {
+  readonly items: Array<Item<unknown>>
+  readonly initialIndex?: number
+  readonly limit?: number
+  readonly isFocused?: boolean
+  readonly orientation?: 'vertical' | 'horizontal'
+  readonly onResult: (result: UseEnhancedSelectInputResult<unknown>) => void
 }
 
-function HookHarness(props: HookHarnessProps) {
-  const { onResult, ...hookProps } = props
-  const result = useEnhancedSelectInput(hookProps)
+function HookHarness(properties: HookHarnessProperties) {
+  const { onResult, ...hookProperties } = properties
+  const result = useEnhancedSelectInput(hookProperties)
   onResult(result)
   return null
 }
@@ -1475,8 +1475,8 @@ test('selection preserved when items update but current slot is still valid', as
 test('warns in development when object-valued items have no key field', async (t) => {
   const warnings: string[] = []
   const originalWarn = console.warn
-  console.warn = (...args: unknown[]) => {
-    warnings.push(String(args[0]))
+  console.warn = (...arguments_: unknown[]) => {
+    warnings.push(String(arguments_[0]))
   }
 
   try {
@@ -1500,8 +1500,8 @@ test('warns in development when object-valued items have no key field', async (t
 test('no duplicate key warning when all items have explicit keys', async (t) => {
   const warnings: string[] = []
   const originalWarn = console.warn
-  console.warn = (...args: unknown[]) => {
-    warnings.push(String(args[0]))
+  console.warn = (...arguments_: unknown[]) => {
+    warnings.push(String(arguments_[0]))
   }
 
   try {
@@ -1529,7 +1529,7 @@ test('multi-select renders checkbox indicators instead of arrow cursor', (t) => 
     { label: 'B', value: 'b' },
     { label: 'C', value: 'c' },
   ]
-  const { lastFrame } = render(<EnhancedSelectInput items={items} multiple />)
+  const { lastFrame } = render(<EnhancedSelectInput multiple items={items} />)
   const frame = lastFrame()!
   t.true(frame.includes('[ ]'))
   t.false(frame.includes('>'))
@@ -1540,7 +1540,9 @@ test('multi-select space toggles checked state on', async (t) => {
     { label: 'A', value: 'a' },
     { label: 'B', value: 'b' },
   ]
-  const { stdin, lastFrame } = render(<EnhancedSelectInput items={items} multiple />)
+  const { stdin, lastFrame } = render(
+    <EnhancedSelectInput multiple items={items} />
+  )
 
   await delay()
   t.false(lastFrame()!.includes('[x]'))
@@ -1553,7 +1555,7 @@ test('multi-select space toggles checked state on', async (t) => {
 test('multi-select space toggles checked state off', async (t) => {
   const items = [{ label: 'A', value: 'a' }]
   const { stdin, lastFrame } = render(
-    <EnhancedSelectInput items={items} multiple defaultSelectedKeys={['a']} />
+    <EnhancedSelectInput multiple items={items} defaultSelectedKeys={['a']} />
   )
 
   await delay()
@@ -1571,11 +1573,15 @@ test('multi-select defaultSelectedKeys pre-checks items', (t) => {
     { label: 'C', value: 'c' },
   ]
   const { lastFrame } = render(
-    <EnhancedSelectInput items={items} multiple defaultSelectedKeys={['a', 'c']} />
+    <EnhancedSelectInput
+      multiple
+      items={items}
+      defaultSelectedKeys={['a', 'c']}
+    />
   )
   const frame = lastFrame()!
-  t.is((frame.match(/\[x\]/g) ?? []).length, 2)
-  t.is((frame.match(/\[ \]/g) ?? []).length, 1)
+  t.is((frame.match(/\[x]/g) ?? []).length, 2)
+  t.is((frame.match(/\[ ]/g) ?? []).length, 1)
 })
 
 test('multi-select enter calls onConfirm with checked items', async (t) => {
@@ -1588,8 +1594,8 @@ test('multi-select enter calls onConfirm with checked items', async (t) => {
   let confirmed: string[] = []
   const { stdin } = render(
     <EnhancedSelectInput
-      items={items}
       multiple
+      items={items}
       onConfirm={(selected) => {
         confirmed = selected.map((item) => String(item.value))
       }}
@@ -1597,13 +1603,13 @@ test('multi-select enter calls onConfirm with checked items', async (t) => {
   )
 
   await delay()
-  stdin.write(SPACE) // check A
+  stdin.write(SPACE) // Check A
   await delay()
   stdin.write(ARROW_DOWN) // → B
   await delay()
   stdin.write(ARROW_DOWN) // → C
   await delay()
-  stdin.write(SPACE) // check C
+  stdin.write(SPACE) // Check C
   await delay()
   stdin.write(ENTER)
   await delay()
@@ -1619,11 +1625,11 @@ test('multi-select enter with nothing checked calls onConfirm with empty array',
     { label: 'B', value: 'b' },
   ]
 
-  let confirmed: unknown[] | null = null
+  let confirmed: unknown[] | undefined
   const { stdin } = render(
     <EnhancedSelectInput
-      items={items}
       multiple
+      items={items}
       onConfirm={(selected) => {
         confirmed = selected
       }}
@@ -1634,7 +1640,7 @@ test('multi-select enter with nothing checked calls onConfirm with empty array',
   stdin.write(ENTER)
   await delay()
 
-  t.not(confirmed, null)
+  t.not(confirmed, undefined)
   t.is(confirmed!.length, 0)
 })
 
@@ -1644,8 +1650,8 @@ test('multi-select onToggle fires with item and checked state', async (t) => {
   const log: Array<{ label: string; checked: boolean }> = []
   const { stdin } = render(
     <EnhancedSelectInput
-      items={items}
       multiple
+      items={items}
       onToggle={(item, checked) => {
         log.push({ label: item.label, checked })
       }}
@@ -1675,8 +1681,8 @@ test('multi-select space only toggles enabled items', async (t) => {
   const toggled: string[] = []
   const { stdin } = render(
     <EnhancedSelectInput
-      items={items}
       multiple
+      items={items}
       onToggle={(item) => {
         toggled.push(item.label)
       }}
@@ -1684,11 +1690,11 @@ test('multi-select space only toggles enabled items', async (t) => {
   )
 
   await delay()
-  stdin.write(SPACE) // toggle A
+  stdin.write(SPACE) // Toggle A
   await delay()
-  stdin.write(ARROW_DOWN) // skip B → land on C
+  stdin.write(ARROW_DOWN) // Skip B → land on C
   await delay()
-  stdin.write(SPACE) // toggle C
+  stdin.write(SPACE) // Toggle C
   await delay()
 
   t.is(toggled.length, 2)
@@ -1706,8 +1712,8 @@ test('multi-select hotkeys do not fire in multi-select mode', async (t) => {
   let selected = ''
   const { stdin } = render(
     <EnhancedSelectInput
-      items={items}
       multiple
+      items={items}
       onSelect={(item) => {
         selected = item.label
       }}
@@ -1726,7 +1732,7 @@ test('multi-select hotkey hints not shown in render', (t) => {
     { label: 'B', value: 'b', hotkey: 'y' },
   ]
 
-  const { lastFrame } = render(<EnhancedSelectInput items={items} multiple />)
+  const { lastFrame } = render(<EnhancedSelectInput multiple items={items} />)
   const frame = lastFrame()!
   t.false(frame.includes('(x)'))
   t.false(frame.includes('(y)'))
@@ -1738,8 +1744,8 @@ test('multi-select isChecked passed to custom indicatorComponent', async (t) => 
   let receivedIsChecked: boolean | undefined
   const { stdin } = render(
     <EnhancedSelectInput
-      items={items}
       multiple
+      items={items}
       indicatorComponent={({ isChecked }) => {
         receivedIsChecked = isChecked
         return null
@@ -1761,8 +1767,8 @@ test('multi-select isChecked passed to custom itemComponent', async (t) => {
   let receivedIsChecked: boolean | undefined
   const { stdin } = render(
     <EnhancedSelectInput
-      items={items}
       multiple
+      items={items}
       itemComponent={({ isChecked }) => {
         receivedIsChecked = isChecked
         return null
@@ -1782,13 +1788,974 @@ test('DefaultIndicatorComponent renders checkboxes in multi-select mode', (t) =>
   const item = { label: 'X', value: 'x' }
 
   const { lastFrame: checkedFrame } = render(
-    <DefaultIndicatorComponent isSelected item={item} isChecked />
+    <DefaultIndicatorComponent isSelected isChecked item={item} />
   )
   const { lastFrame: uncheckedFrame } = render(
-    <DefaultIndicatorComponent isSelected={false} item={item} isChecked={false} />
+    <DefaultIndicatorComponent
+      isSelected={false}
+      item={item}
+      isChecked={false}
+    />
   )
 
   t.true(checkedFrame()!.includes('[x]'))
   t.true(uncheckedFrame()!.includes('[ ]'))
   t.false(checkedFrame()!.includes('>'))
+})
+
+// --- Item Groups ---
+
+test('group headers are rendered before grouped items', (t) => {
+  const items = [
+    { label: 'A', value: 'a', group: 'Recent' },
+    { label: 'B', value: 'b', group: 'Recent' },
+    { label: 'C', value: 'c', group: 'All' },
+  ]
+
+  const { lastFrame } = render(<EnhancedSelectInput items={items} />)
+
+  const frame = lastFrame()!
+  t.true(frame.includes('── Recent ──'))
+  t.true(frame.includes('── All ──'))
+  t.true(frame.includes('A'))
+  t.true(frame.includes('B'))
+  t.true(frame.includes('C'))
+})
+
+test('group header appears only once per group in visible window', (t) => {
+  const items = [
+    { label: 'A', value: 'a', group: 'Fruits' },
+    { label: 'B', value: 'b', group: 'Fruits' },
+    { label: 'C', value: 'c', group: 'Fruits' },
+  ]
+
+  const { lastFrame } = render(<EnhancedSelectInput items={items} />)
+
+  const frame = lastFrame()!
+  const matches = frame.split('── Fruits ──')
+  // Split produces N+1 parts for N occurrences, so 2 parts = 1 occurrence
+  t.is(matches.length, 2)
+})
+
+test('group headers are non-navigable (navigation skips them)', async (t) => {
+  const items = [
+    { label: 'A', value: 'a', group: 'First' },
+    { label: 'B', value: 'b', group: 'Second' },
+  ]
+
+  let highlighted = ''
+  const { stdin } = render(
+    <EnhancedSelectInput
+      items={items}
+      onHighlight={(item) => {
+        highlighted = item.label
+      }}
+    />
+  )
+
+  await delay()
+  t.is(highlighted, 'A')
+
+  stdin.write(ARROW_DOWN)
+  await delay()
+  // Should navigate to B, not get stuck on a header
+  t.is(highlighted, 'B')
+})
+
+test('items without group do not render a header', (t) => {
+  const items = [
+    { label: 'A', value: 'a' },
+    { label: 'B', value: 'b' },
+  ]
+
+  const { lastFrame } = render(<EnhancedSelectInput items={items} />)
+
+  const frame = lastFrame()!
+  t.false(frame.includes('──'))
+})
+
+test('mixed grouped and ungrouped items render correctly', (t) => {
+  const items = [
+    { label: 'A', value: 'a' },
+    { label: 'B', value: 'b', group: 'Special' },
+    { label: 'C', value: 'c', group: 'Special' },
+  ]
+
+  const { lastFrame } = render(<EnhancedSelectInput items={items} />)
+
+  const frame = lastFrame()!
+  t.true(frame.includes('A'))
+  t.true(frame.includes('── Special ──'))
+  t.true(frame.includes('B'))
+  t.true(frame.includes('C'))
+  // No header for ungrouped item A
+  const lines = frame.split('\n')
+  t.false(lines[0]!.includes('──'))
+})
+
+test('custom groupHeaderComponent is used when provided', (t) => {
+  const items = [
+    { label: 'A', value: 'a', group: 'Custom' },
+    { label: 'B', value: 'b', group: 'Custom' },
+  ]
+
+  const { lastFrame } = render(
+    <EnhancedSelectInput
+      items={items}
+      groupHeaderComponent={({ label }) => <Text>[{label}]</Text>}
+    />
+  )
+
+  const frame = lastFrame()!
+  t.true(frame.includes('[Custom]'))
+  t.false(frame.includes('──'))
+})
+
+test('group headers render correctly with limit/pagination', async (t) => {
+  const items = [
+    { label: 'A', value: 'a', group: 'First' },
+    { label: 'B', value: 'b', group: 'First' },
+    { label: 'C', value: 'c', group: 'Second' },
+    { label: 'D', value: 'd', group: 'Second' },
+  ]
+
+  let highlighted = ''
+  const { stdin, lastFrame } = render(
+    <EnhancedSelectInput
+      items={items}
+      limit={2}
+      onHighlight={(item) => {
+        highlighted = item.label
+      }}
+    />
+  )
+
+  await delay()
+  // Initial window shows A and B (both in "First" group)
+  const frame1 = lastFrame()!
+  t.true(frame1.includes('── First ──'))
+  t.true(frame1.includes('A'))
+  t.true(frame1.includes('B'))
+
+  // Navigate to C — window scrolls to show C and D
+  stdin.write(ARROW_DOWN)
+  await delay()
+  stdin.write(ARROW_DOWN)
+  await delay()
+  t.is(highlighted, 'C')
+
+  const frame2 = lastFrame()!
+  t.true(frame2.includes('── Second ──'))
+  t.true(frame2.includes('C'))
+  t.true(frame2.includes('D'))
+})
+// --- Additional Group Tests ---
+
+test('group headers render in horizontal orientation', (t) => {
+  const items = [
+    { label: 'A', value: 'a', group: 'Left' },
+    { label: 'B', value: 'b', group: 'Right' },
+  ]
+
+  const { lastFrame } = render(
+    <EnhancedSelectInput items={items} orientation="horizontal" />
+  )
+
+  const frame = lastFrame()!
+  t.true(frame.includes('── Left ──'))
+  t.true(frame.includes('── Right ──'))
+})
+
+test('group headers work with multi-select mode', async (t) => {
+  const items = [
+    { label: 'A', value: 'a', group: 'Group1' },
+    { label: 'B', value: 'b', group: 'Group1' },
+  ]
+
+  const { stdin, lastFrame } = render(
+    <EnhancedSelectInput multiple items={items} />
+  )
+
+  await delay()
+  const frame1 = lastFrame()!
+  t.true(frame1.includes('── Group1 ──'))
+  t.true(frame1.includes('[ ]'))
+
+  stdin.write(SPACE)
+  await delay()
+  const frame2 = lastFrame()!
+  t.true(frame2.includes('[x]'))
+  t.true(frame2.includes('── Group1 ──'))
+})
+
+test('group headers render for groups containing disabled items', (t) => {
+  const items = [
+    { label: 'A', value: 'a', group: 'Tools', disabled: true },
+    { label: 'B', value: 'b', group: 'Tools' },
+  ]
+
+  const { lastFrame } = render(<EnhancedSelectInput items={items} />)
+
+  const frame = lastFrame()!
+  t.true(frame.includes('── Tools ──'))
+  t.true(frame.includes('A'))
+  t.true(frame.includes('B'))
+})
+
+test('non-contiguous items with same group get separate headers per window', (t) => {
+  // When items with the same group appear in different positions,
+  // the header renders before the first occurrence in the visible window
+  const items = [
+    { label: 'A', value: 'a', group: 'Alpha' },
+    { label: 'B', value: 'b', group: 'Beta' },
+    { label: 'C', value: 'c', group: 'Alpha' },
+  ]
+
+  const { lastFrame } = render(<EnhancedSelectInput items={items} />)
+
+  const frame = lastFrame()!
+  // "Alpha" header should only appear once (before first occurrence)
+  const alphaMatches = frame.split('── Alpha ──')
+  t.is(alphaMatches.length, 2) // 1 occurrence
+  t.true(frame.includes('── Beta ──'))
+})
+
+test('group headers with showScrollIndicators', (t) => {
+  const items = [
+    { label: 'A', value: 'a', group: 'First' },
+    { label: 'B', value: 'b', group: 'First' },
+    { label: 'C', value: 'c', group: 'Second' },
+    { label: 'D', value: 'd', group: 'Second' },
+  ]
+
+  const { lastFrame } = render(
+    <EnhancedSelectInput showScrollIndicators items={items} limit={2} />
+  )
+
+  const frame = lastFrame()!
+  t.true(frame.includes('── First ──'))
+  t.true(frame.includes('▼'))
+  t.true(frame.includes('2 more'))
+})
+
+// --- DefaultGroupHeaderComponent isolation ---
+
+test('DefaultGroupHeaderComponent renders label with decorators', (t) => {
+  const { lastFrame } = render(<DefaultGroupHeaderComponent label="My Group" />)
+
+  const frame = lastFrame()!
+  t.true(frame.includes('── My Group ──'))
+})
+
+// --- Edge Cases: Single Item ---
+
+test('single item list: navigation wraps to itself', async (t) => {
+  const items = [{ label: 'Only', value: 'only' }]
+
+  let highlighted = ''
+  const { stdin } = render(
+    <EnhancedSelectInput
+      items={items}
+      onHighlight={(item) => {
+        highlighted = item.label
+      }}
+    />
+  )
+
+  await delay()
+  t.is(highlighted, 'Only')
+
+  stdin.write(ARROW_DOWN)
+  await delay()
+  t.is(highlighted, 'Only')
+
+  stdin.write(ARROW_UP)
+  await delay()
+  t.is(highlighted, 'Only')
+})
+
+// --- Edge Cases: limit ---
+
+test('limit larger than items count shows all items', (t) => {
+  const items = [
+    { label: 'A', value: 'a' },
+    { label: 'B', value: 'b' },
+  ]
+
+  const { lastFrame } = render(<EnhancedSelectInput items={items} limit={10} />)
+
+  const frame = lastFrame()!
+  t.true(frame.includes('A'))
+  t.true(frame.includes('B'))
+  t.is(frame.split('\n').length, 2)
+})
+
+test('limit=1 shows single item at a time', async (t) => {
+  const items = [
+    { label: 'A', value: 'a' },
+    { label: 'B', value: 'b' },
+    { label: 'C', value: 'c' },
+  ]
+
+  let highlighted = ''
+  const { stdin, lastFrame } = render(
+    <EnhancedSelectInput
+      items={items}
+      limit={1}
+      onHighlight={(item) => {
+        highlighted = item.label
+      }}
+    />
+  )
+
+  await delay()
+  t.is(highlighted, 'A')
+  let frame = lastFrame()!
+  t.is(frame.split('\n').length, 1)
+  t.true(frame.includes('A'))
+
+  stdin.write(ARROW_DOWN)
+  await delay()
+  t.is(highlighted, 'B')
+  frame = lastFrame()!
+  t.true(frame.includes('B'))
+  t.false(frame.includes('A'))
+})
+
+// --- Escape in multi-select mode ---
+
+test('Escape calls onCancel in multi-select mode', async (t) => {
+  const items = [
+    { label: 'A', value: 'a' },
+    { label: 'B', value: 'b' },
+  ]
+
+  let cancelled = false
+  const { stdin } = render(
+    <EnhancedSelectInput
+      multiple
+      items={items}
+      onCancel={() => {
+        cancelled = true
+      }}
+    />
+  )
+
+  await delay()
+  stdin.write(SPACE) // Toggle A
+  await delay()
+  stdin.write(ESCAPE)
+  await delay()
+  t.true(cancelled)
+})
+
+// --- Home/End in horizontal orientation ---
+
+test('Home key works in horizontal orientation', async (t) => {
+  const items = [
+    { label: 'A', value: 'a' },
+    { label: 'B', value: 'b' },
+    { label: 'C', value: 'c' },
+  ]
+
+  let highlighted = ''
+  const { stdin } = render(
+    <EnhancedSelectInput
+      items={items}
+      orientation="horizontal"
+      initialIndex={2}
+      onHighlight={(item) => {
+        highlighted = item.label
+      }}
+    />
+  )
+
+  await delay()
+  t.is(highlighted, 'C')
+
+  stdin.write(HOME)
+  await delay()
+  t.is(highlighted, 'A')
+})
+
+test('End key works in horizontal orientation', async (t) => {
+  const items = [
+    { label: 'A', value: 'a' },
+    { label: 'B', value: 'b' },
+    { label: 'C', value: 'c' },
+  ]
+
+  let highlighted = ''
+  const { stdin } = render(
+    <EnhancedSelectInput
+      items={items}
+      orientation="horizontal"
+      onHighlight={(item) => {
+        highlighted = item.label
+      }}
+    />
+  )
+
+  await delay()
+  stdin.write(END)
+  await delay()
+  t.is(highlighted, 'C')
+})
+
+// --- Multi-select with item.key field ---
+
+test('multi-select defaultSelectedKeys works with explicit item.key', (t) => {
+  const items = [
+    { key: 'k1', label: 'A', value: { id: 1 } },
+    { key: 'k2', label: 'B', value: { id: 2 } },
+    { key: 'k3', label: 'C', value: { id: 3 } },
+  ]
+
+  const { lastFrame } = render(
+    <EnhancedSelectInput
+      multiple
+      items={items}
+      defaultSelectedKeys={['k1', 'k3']}
+    />
+  )
+
+  const frame = lastFrame()!
+  t.is((frame.match(/\[x]/g) ?? []).length, 2)
+  t.is((frame.match(/\[ ]/g) ?? []).length, 1)
+})
+
+// --- Hook: isFocused=false ---
+
+test('hook ignores all input when isFocused=false', async (t) => {
+  const items = [
+    { label: 'A', value: 'a' },
+    { label: 'B', value: 'b' },
+  ]
+
+  let result: UseEnhancedSelectInputResult<unknown> | undefined
+  const { stdin } = render(
+    <HookHarness
+      items={items}
+      isFocused={false}
+      onResult={(r) => {
+        result = r
+      }}
+    />
+  )
+
+  await delay()
+  t.is(result?.selectedIndex, 0)
+
+  stdin.write(ARROW_DOWN)
+  await delay()
+  t.is(result?.selectedIndex, 0)
+
+  stdin.write('j')
+  await delay()
+  t.is(result?.selectedIndex, 0)
+})
+
+// --- Navigation on empty items does nothing ---
+
+test('keyboard input on empty items does not crash', async (t) => {
+  const { stdin, lastFrame } = render(<EnhancedSelectInput items={[]} />)
+
+  await delay()
+  // Should not throw
+  stdin.write(ARROW_DOWN)
+  await delay()
+  stdin.write(ARROW_UP)
+  await delay()
+  stdin.write(ENTER)
+  await delay()
+  stdin.write(ESCAPE)
+  await delay()
+  stdin.write(HOME)
+  await delay()
+  stdin.write(END)
+  await delay()
+
+  const frame = lastFrame()
+  t.true(frame !== undefined)
+})
+
+// --- Hotkey updates highlight position ---
+
+test('hotkey updates selectedIndex to the hotkey item', async (t) => {
+  const items = [
+    { label: 'A', value: 'a', hotkey: 'x' },
+    { label: 'B', value: 'b', hotkey: 'y' },
+    { label: 'C', value: 'c', hotkey: 'z' },
+  ]
+
+  let highlighted = ''
+  const { stdin } = render(
+    <EnhancedSelectInput
+      items={items}
+      onHighlight={(item) => {
+        highlighted = item.label
+      }}
+    />
+  )
+
+  await delay()
+  t.is(highlighted, 'A')
+
+  stdin.write('z')
+  await delay()
+  t.is(highlighted, 'C')
+
+  // Subsequent arrow navigation should continue from C
+  stdin.write(ARROW_UP)
+  await delay()
+  t.is(highlighted, 'B')
+})
+
+// --- Hotkey in horizontal mode with h/l conflict ---
+
+test('h/l hotkeys are ignored in horizontal orientation (nav takes priority)', async (t) => {
+  const items = [
+    { label: 'A', value: 'a', hotkey: 'h' },
+    { label: 'B', value: 'b', hotkey: 'l' },
+    { label: 'C', value: 'c' },
+  ]
+
+  let selected = ''
+  let highlighted = ''
+  const { stdin } = render(
+    <EnhancedSelectInput
+      items={items}
+      orientation="horizontal"
+      onSelect={(item) => {
+        selected = item.label
+      }}
+      onHighlight={(item) => {
+        highlighted = item.label
+      }}
+    />
+  )
+
+  await delay()
+  t.is(highlighted, 'A')
+
+  // 'l' should navigate right, not trigger hotkey
+  stdin.write('l')
+  await delay()
+  t.is(highlighted, 'B')
+  t.is(selected, '')
+
+  // 'h' should navigate left, not trigger hotkey
+  stdin.write('h')
+  await delay()
+  t.is(highlighted, 'A')
+  t.is(selected, '')
+})
+
+// --- onSelect not provided does not crash ---
+
+test('enter without onSelect does not crash', async (t) => {
+  const items = [
+    { label: 'A', value: 'a' },
+    { label: 'B', value: 'b' },
+  ]
+
+  const { stdin, lastFrame } = render(<EnhancedSelectInput items={items} />)
+
+  await delay()
+  stdin.write(ENTER)
+  await delay()
+
+  const frame = lastFrame()!
+  t.true(frame.includes('A'))
+})
+
+// --- onHighlight not provided does not crash ---
+
+test('navigation without onHighlight does not crash', async (t) => {
+  const items = [
+    { label: 'A', value: 'a' },
+    { label: 'B', value: 'b' },
+  ]
+
+  const { stdin, lastFrame } = render(<EnhancedSelectInput items={items} />)
+
+  await delay()
+  stdin.write(ARROW_DOWN)
+  await delay()
+
+  const frame = lastFrame()!
+  t.true(frame.includes('B'))
+})
+
+// --- Multi-select: navigation still works ---
+
+test('multi-select navigation with arrow keys works', async (t) => {
+  const items = [
+    { label: 'A', value: 'a' },
+    { label: 'B', value: 'b' },
+    { label: 'C', value: 'c' },
+  ]
+
+  let highlighted = ''
+  const { stdin } = render(
+    <EnhancedSelectInput
+      multiple
+      items={items}
+      onHighlight={(item) => {
+        highlighted = item.label
+      }}
+    />
+  )
+
+  await delay()
+  t.is(highlighted, 'A')
+
+  stdin.write(ARROW_DOWN)
+  await delay()
+  t.is(highlighted, 'B')
+
+  stdin.write(ARROW_DOWN)
+  await delay()
+  t.is(highlighted, 'C')
+
+  stdin.write(ARROW_UP)
+  await delay()
+  t.is(highlighted, 'B')
+})
+
+// --- Multi-select: Home/End work ---
+
+test('multi-select Home/End navigation works', async (t) => {
+  const items = [
+    { label: 'A', value: 'a' },
+    { label: 'B', value: 'b' },
+    { label: 'C', value: 'c' },
+  ]
+
+  let highlighted = ''
+  const { stdin } = render(
+    <EnhancedSelectInput
+      multiple
+      items={items}
+      onHighlight={(item) => {
+        highlighted = item.label
+      }}
+    />
+  )
+
+  await delay()
+  stdin.write(END)
+  await delay()
+  t.is(highlighted, 'C')
+
+  stdin.write(HOME)
+  await delay()
+  t.is(highlighted, 'A')
+})
+
+// --- Indicator component receives the item ---
+
+test('indicatorComponent receives the current item', (t) => {
+  const items = [
+    { label: 'A', value: 'a' },
+    { label: 'B', value: 'b' },
+  ]
+
+  const receivedItems: string[] = []
+  render(
+    <EnhancedSelectInput
+      items={items}
+      indicatorComponent={({ item }) => {
+        receivedItems.push(item.label)
+        return null
+      }}
+    />
+  )
+
+  t.true(receivedItems.includes('A'))
+  t.true(receivedItems.includes('B'))
+})
+
+// --- Per-item indicator only shows when selected ---
+
+test('per-item indicator only shows for selected item', async (t) => {
+  const items = [
+    { label: 'A', value: 'a', indicator: '★' },
+    { label: 'B', value: 'b', indicator: '●' },
+  ]
+
+  const { stdin, lastFrame } = render(<EnhancedSelectInput items={items} />)
+
+  await delay()
+  let frame = lastFrame()!
+  t.true(frame.includes('★'))
+  // B's indicator should not show (space placeholder instead)
+  t.false(frame.includes('●'))
+
+  stdin.write(ARROW_DOWN)
+  await delay()
+  frame = lastFrame()!
+  t.true(frame.includes('●'))
+  // A is no longer selected, its indicator should be hidden
+  t.false(frame.includes('★'))
+})
+
+// --- Scroll indicators in horizontal mode ---
+
+test('showScrollIndicators uses ◀/▶ in horizontal mode', (t) => {
+  const items = [
+    { label: 'A', value: 'a' },
+    { label: 'B', value: 'b' },
+    { label: 'C', value: 'c' },
+    { label: 'D', value: 'd' },
+  ]
+
+  const { lastFrame } = render(
+    <EnhancedSelectInput
+      showScrollIndicators
+      items={items}
+      limit={2}
+      orientation="horizontal"
+      initialIndex={2}
+    />
+  )
+
+  const frame = lastFrame()!
+  t.true(frame.includes('◀'))
+  t.true(frame.includes('2 more'))
+  // No items below since we're at the end
+  t.false(frame.includes('▲'))
+  t.false(frame.includes('▼'))
+})
+
+// --- Rapid navigation ---
+
+test('rapid sequential navigation lands on correct item', async (t) => {
+  const items = [
+    { label: 'A', value: 'a' },
+    { label: 'B', value: 'b' },
+    { label: 'C', value: 'c' },
+    { label: 'D', value: 'd' },
+    { label: 'E', value: 'e' },
+  ]
+
+  let highlighted = ''
+  const { stdin } = render(
+    <EnhancedSelectInput
+      items={items}
+      onHighlight={(item) => {
+        highlighted = item.label
+      }}
+    />
+  )
+
+  await delay()
+  stdin.write(ARROW_DOWN)
+  await delay()
+  stdin.write(ARROW_DOWN)
+  await delay()
+  stdin.write(ARROW_DOWN)
+  await delay()
+  stdin.write(ARROW_DOWN)
+  await delay()
+  t.is(highlighted, 'E')
+})
+
+// --- onHighlight fires on initial render ---
+
+test('onHighlight fires on initial mount', async (t) => {
+  const items = [
+    { label: 'A', value: 'a' },
+    { label: 'B', value: 'b' },
+  ]
+
+  let highlighted = ''
+  render(
+    <EnhancedSelectInput
+      items={items}
+      onHighlight={(item) => {
+        highlighted = item.label
+      }}
+    />
+  )
+
+  await delay()
+  t.is(highlighted, 'A')
+})
+
+test('onHighlight fires with correct item when initialIndex is set', async (t) => {
+  const items = [
+    { label: 'A', value: 'a' },
+    { label: 'B', value: 'b' },
+    { label: 'C', value: 'c' },
+  ]
+
+  let highlighted = ''
+  render(
+    <EnhancedSelectInput
+      items={items}
+      initialIndex={1}
+      onHighlight={(item) => {
+        highlighted = item.label
+      }}
+    />
+  )
+
+  await delay()
+  t.is(highlighted, 'B')
+})
+
+// --- Generic value type ---
+
+test('works with complex object values when key is provided', async (t) => {
+  type MyValue = { id: number; name: string }
+  const items: Array<{ key: string; label: string; value: MyValue }> = [
+    { key: 'item-1', label: 'First', value: { id: 1, name: 'one' } },
+    { key: 'item-2', label: 'Second', value: { id: 2, name: 'two' } },
+  ]
+
+  let selected: MyValue | undefined
+  const { stdin } = render(
+    <EnhancedSelectInput
+      items={items}
+      onSelect={(item) => {
+        selected = item.value
+      }}
+    />
+  )
+
+  await delay()
+  stdin.write(ARROW_DOWN)
+  await delay()
+  stdin.write(ENTER)
+  await delay()
+
+  t.not(selected, undefined)
+  t.is(selected?.id, 2)
+  t.is(selected?.name, 'two')
+})
+
+// --- Multi-select: toggle then navigate then confirm ---
+
+test('multi-select: toggle multiple items across navigation then confirm', async (t) => {
+  const items = [
+    { label: 'A', value: 'a' },
+    { label: 'B', value: 'b' },
+    { label: 'C', value: 'c' },
+    { label: 'D', value: 'd' },
+  ]
+
+  let confirmed: string[] = []
+  const { stdin } = render(
+    <EnhancedSelectInput
+      multiple
+      items={items}
+      onConfirm={(selected) => {
+        confirmed = selected.map((item) => String(item.value))
+      }}
+    />
+  )
+
+  await delay()
+  stdin.write(SPACE) // Check A
+  await delay()
+  stdin.write(ARROW_DOWN) // → B
+  await delay()
+  stdin.write(ARROW_DOWN) // → C
+  await delay()
+  stdin.write(SPACE) // Check C
+  await delay()
+  stdin.write(ARROW_DOWN) // → D
+  await delay()
+  stdin.write(SPACE) // Check D
+  await delay()
+  stdin.write(ARROW_UP) // → C
+  await delay()
+  stdin.write(SPACE) // Uncheck C
+  await delay()
+  stdin.write(ENTER)
+  await delay()
+
+  t.is(confirmed.length, 2)
+  t.true(confirmed.includes('a'))
+  t.true(confirmed.includes('d'))
+  t.false(confirmed.includes('c'))
+})
+
+// --- Items update: items grow ---
+
+test('selection stays valid when items grow', async (t) => {
+  const items = [
+    { label: 'A', value: 'a' },
+    { label: 'B', value: 'b' },
+  ]
+
+  let highlighted = ''
+  const { rerender } = render(
+    <EnhancedSelectInput
+      items={items}
+      initialIndex={1}
+      onHighlight={(item) => {
+        highlighted = item.label
+      }}
+    />
+  )
+
+  await delay()
+  t.is(highlighted, 'B')
+
+  // Add more items — selection should stay on B
+  rerender(
+    <EnhancedSelectInput
+      items={[
+        { label: 'A', value: 'a' },
+        { label: 'B', value: 'b' },
+        { label: 'C', value: 'c' },
+        { label: 'D', value: 'd' },
+      ]}
+      initialIndex={1}
+      onHighlight={(item) => {
+        highlighted = item.label
+      }}
+    />
+  )
+
+  await delay()
+  t.is(highlighted, 'B')
+})
+
+// --- Items update: items replaced entirely ---
+
+test('selection resets when items are completely replaced', async (t) => {
+  let highlighted = ''
+  const { rerender } = render(
+    <EnhancedSelectInput
+      items={[
+        { label: 'A', value: 'a' },
+        { label: 'B', value: 'b' },
+        { label: 'C', value: 'c' },
+      ]}
+      initialIndex={2}
+      onHighlight={(item) => {
+        highlighted = item.label
+      }}
+    />
+  )
+
+  await delay()
+  t.is(highlighted, 'C')
+
+  // Replace with completely different items (only 1 item)
+  rerender(
+    <EnhancedSelectInput
+      items={[{ label: 'X', value: 'x' }]}
+      initialIndex={2}
+      onHighlight={(item) => {
+        highlighted = item.label
+      }}
+    />
+  )
+
+  await delay()
+  t.is(highlighted, 'X')
 })


### PR DESCRIPTION
## Summary

Implements #13 — adds support for visually grouping items under section headers.

Also significantly expands test coverage (75 → 106 tests).

## Changes

### Item Groups (#13)
- Added `group?: string` field to `Item<V>` type
- Items sharing the same `group` value are rendered under a shared header row
- Headers are purely visual and non-navigable (not items in the array)
- Added `DefaultGroupHeaderComponent` (renders `── GroupName ──` with dim styling)
- Added `groupHeaderComponent` prop for custom header rendering
- Exported `DefaultGroupHeaderComponent` and `GroupHeaderProperties` from package entry
- Documented in README with usage examples, props table, and Item Shape

### Test Coverage
- **31 new tests** covering:
  - All group rendering scenarios (horizontal, multi-select, disabled items, pagination, scroll indicators)
  - Edge cases: single item, limit=1, limit > items, empty items keyboard input
  - Multi-select: Home/End, navigation, toggle workflows
  - Horizontal orientation: Home/End, scroll indicators
  - Per-item indicator visibility toggling
  - Complex object value types with explicit keys
  - Items update scenarios (grow, shrink, replace)
  - onHighlight fires on mount
  - Callbacks not provided don't crash
- Increased test delay default from 50ms → 100ms for stability under concurrent load

## Testing

```
yarn test  # 106 tests passed
```

Closes #13