### PR TITLE
feat: searchable mode for inline item filtering

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -169,6 +169,46 @@ You can provide a custom header renderer via `groupHeaderComponent`:
 />
 ```
 
+### Searchable Mode
+
+Enable inline filtering with the `searchable` prop. Printable characters build a search query that filters items by label (case-insensitive substring match). A search input line renders above the item list.
+
+```tsx
+<EnhancedSelectInput
+  items={items}
+  searchable
+  searchPlaceholder="Filter options..."
+  onSelect={(item) => console.log(item.value)}
+/>
+```
+
+Renders:
+
+```
+/ Filter options...
+> Option A
+  Option B
+  Option C
+```
+
+When typing:
+
+```
+/ app
+> Apple
+  Pineapple
+```
+
+**Key behavior in searchable mode:**
+
+- Printable characters are captured as search input
+- `Backspace` removes the last character from the query
+- `Escape` clears the query; if already empty, calls `onCancel`
+- Arrow keys navigate the filtered results
+- Vim keys (`h/j/k/l`) are treated as search characters, not navigation
+- Hotkeys are disabled (characters go to the search query)
+- "No matches" is shown when the query matches nothing
+
 ### Custom Components
 
 ```tsx
@@ -226,7 +266,7 @@ function MyCustomSelect({ items, onSelect }) {
 }
 ```
 
-The hook accepts all the same props as `EnhancedSelectInput` except `indicatorComponent`, `itemComponent`, `groupHeaderComponent`, and `showScrollIndicators`. It returns `{ selectedIndex, rotateIndex, visibleItems, hasItems, itemsAbove, itemsBelow, checkedKeys }`. `checkedKeys` is a `Set<string>` of checked item keys — only populated when `multiple` is `true`.
+The hook accepts all the same props as `EnhancedSelectInput` except `indicatorComponent`, `itemComponent`, `groupHeaderComponent`, `showScrollIndicators`, and `searchPlaceholder`. It returns `{ selectedIndex, rotateIndex, visibleItems, hasItems, itemsAbove, itemsBelow, checkedKeys, searchQuery }`. `checkedKeys` is a `Set<string>` of checked item keys — only populated when `multiple` is `true`. `searchQuery` is the current filter string — empty when `searchable` is false.
 
 ## Props
 
@@ -248,6 +288,8 @@ The hook accepts all the same props as `EnhancedSelectInput` except `indicatorCo
 | `onConfirm`            | `(items: Array<Item<V>>) => void`           | —                             | Called on Enter in multi-select mode with all checked items |
 | `onToggle`             | `(item: Item<V>, checked: boolean) => void` | —                             | Called each time an item is toggled in multi-select mode    |
 | `groupHeaderComponent` | `FC<GroupHeaderProps>`                      | `DefaultGroupHeaderComponent` | Custom group header renderer                                |
+| `searchable`           | `boolean`                                   | `false`                       | Enable inline search/filter mode                            |
+| `searchPlaceholder`    | `string`                                    | `'Search...'`                 | Placeholder text shown when search query is empty           |
 
 ### Item Shape
 

--- a/src/enhanced-select-input/index.tsx
+++ b/src/enhanced-select-input/index.tsx
@@ -48,6 +48,12 @@ export type UseEnhancedSelectInputProperties<V> = {
    * Receives the toggled item and whether it is now checked.
    */
   readonly onToggle?: (item: Item<V>, checked: boolean) => void
+  /**
+   * Enable searchable/filterable mode. When true, printable characters
+   * build a search query that filters items by label. Hotkeys and vim
+   * navigation keys are disabled in this mode.
+   */
+  readonly searchable?: boolean
 }
 
 /** Full component props — hook props plus rendering customisation. */
@@ -62,6 +68,15 @@ export type Properties<V> = UseEnhancedSelectInputProperties<V> & {
    */
   // eslint-disable-next-line react/boolean-prop-naming
   readonly showScrollIndicators?: boolean
+  /**
+   * Enable searchable/filterable mode. When true, printable characters
+   * build a search query that filters items by label. Hotkeys and vim
+   * navigation keys are disabled in this mode.
+   */
+  // eslint-disable-next-line react/boolean-prop-naming
+  readonly searchable?: boolean
+  /** Placeholder text shown in the search input when the query is empty. */
+  readonly searchPlaceholder?: string
 }
 
 export type IndicatorProperties = {
@@ -147,13 +162,13 @@ function itemKey<V>(item: Item<V>): string {
 }
 
 export type UseEnhancedSelectInputResult<V> = {
-  /** Index of the currently highlighted item within the full items array. */
+  /** Index of the currently highlighted item within the filtered items array. */
   selectedIndex: number
   /** Start of the current pagination window (0 when limit is not set). */
   rotateIndex: number
   /** The slice of items visible in the current window. */
   visibleItems: Array<Item<V>>
-  /** True when items is non-empty. */
+  /** True when filtered items is non-empty. */
   hasItems: boolean
   /** Number of items hidden above the current window. */
   itemsAbove: number
@@ -161,6 +176,8 @@ export type UseEnhancedSelectInputResult<V> = {
   itemsBelow: number
   /** Keys of checked items. Only populated in multi-select mode. */
   checkedKeys: Set<string>
+  /** Current search query. Empty string when searchable is false or no input yet. */
+  searchQuery: string
 }
 
 /**
@@ -181,8 +198,19 @@ export function useEnhancedSelectInput<V>({
   defaultSelectedKeys,
   onConfirm,
   onToggle,
+  searchable = false,
 }: UseEnhancedSelectInputProperties<V>): UseEnhancedSelectInputResult<V> {
-  const safeInitialIndex = resolveInitialIndex(items, initialIndex)
+  const [searchQuery, setSearchQuery] = useState('')
+
+  // Filter items based on search query
+  const filteredItems =
+    searchable && searchQuery
+      ? items.filter((item) =>
+          item.label.toLowerCase().includes(searchQuery.toLowerCase())
+        )
+      : items
+
+  const safeInitialIndex = resolveInitialIndex(filteredItems, initialIndex)
   const [selectedIndex, setSelectedIndex] = useState(safeInitialIndex)
   const [rotateIndex, setRotateIndex] = useState(
     limit ? Math.floor(safeInitialIndex / limit) * limit : 0
@@ -191,12 +219,14 @@ export function useEnhancedSelectInput<V>({
     () => new Set(defaultSelectedKeys ?? [])
   )
 
-  const hasItems = items.length > 0
+  const hasItems = filteredItems.length > 0
   const visibleItems = limit
-    ? items.slice(rotateIndex, rotateIndex + limit)
-    : items
+    ? filteredItems.slice(rotateIndex, rotateIndex + limit)
+    : filteredItems
   const itemsAbove = rotateIndex
-  const itemsBelow = limit ? Math.max(0, items.length - rotateIndex - limit) : 0
+  const itemsBelow = limit
+    ? Math.max(0, filteredItems.length - rotateIndex - limit)
+    : 0
 
   // When the items array changes, re-validate the current selectedIndex.
   // If the item at that position is still enabled we keep it; otherwise we
@@ -226,22 +256,27 @@ export function useEnhancedSelectInput<V>({
       }
     }
 
-    if (items.length === 0) return
-    const currentItem = items[selectedIndex]
+    if (filteredItems.length === 0) {
+      setSelectedIndex(0)
+      if (limit) setRotateIndex(0)
+      return
+    }
+
+    const currentItem = filteredItems[selectedIndex]
     if (!currentItem || currentItem.disabled) {
-      const newIndex = resolveInitialIndex(items, selectedIndex)
+      const newIndex = resolveInitialIndex(filteredItems, selectedIndex)
       setSelectedIndex(newIndex)
       if (limit) setRotateIndex(Math.floor(newIndex / limit) * limit)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [items])
+  }, [items, searchQuery])
 
   // Only re-fire when the highlighted index changes, not when the items
   // array reference changes (which would cause spurious calls on every
   // parent re-render that passes a new array with identical content).
   useEffect(() => {
     if (hasItems) {
-      const highlightedItem = items[selectedIndex]
+      const highlightedItem = filteredItems[selectedIndex]
       if (highlightedItem) {
         onHighlight?.(highlightedItem)
       }
@@ -259,21 +294,38 @@ export function useEnhancedSelectInput<V>({
   useInput(
     // eslint-disable-next-line complexity
     (input, key) => {
-      if (!hasItems) return
+      // In searchable mode, handle Backspace to remove last character
+      if (searchable && key.backspace) {
+        setSearchQuery((previous) => previous.slice(0, -1))
+        setSelectedIndex(0)
+        if (limit) setRotateIndex(0)
+        return
+      }
+
+      // In searchable mode, Escape clears the query first; if already
+      // empty, it falls through to onCancel.
+      if (searchable && key.escape && searchQuery) {
+        setSearchQuery('')
+        setSelectedIndex(0)
+        if (limit) setRotateIndex(0)
+        return
+      }
+
+      if (!hasItems && !searchable) return
 
       // eslint-disable-next-line unicorn/prevent-abbreviations
       const navKeys =
         orientation === 'vertical' ? VERTICAL_NAV_KEYS : HORIZONTAL_NAV_KEYS
       // eslint-disable-next-line unicorn/prevent-abbreviations
-      const isNavKey = navKeys.has(input)
+      const isNavKey = !searchable && navKeys.has(input)
 
       if (key.home) {
-        updateSelection(findFirstValidIndex(items))
+        updateSelection(findFirstValidIndex(filteredItems))
         return
       }
 
       if (key.end) {
-        updateSelection(findLastValidIndex(items))
+        updateSelection(findLastValidIndex(filteredItems))
         return
       }
 
@@ -282,9 +334,10 @@ export function useEnhancedSelectInput<V>({
         return
       }
 
-      // Space: toggle in multi-select mode
-      if (multiple && input === ' ') {
-        const item = items[selectedIndex]
+      // Space: toggle in multi-select mode (but not in searchable mode
+      // where space is a valid search character)
+      if (multiple && !searchable && input === ' ') {
+        const item = filteredItems[selectedIndex]
         if (item && !item.disabled) {
           const k = itemKey(item)
           setCheckedKeys((previous) => {
@@ -303,20 +356,20 @@ export function useEnhancedSelectInput<V>({
       let nextIndex = selectedIndex
 
       if (orientation === 'vertical') {
-        if (key.upArrow || input === 'k') {
-          nextIndex = findNextValidIndex(items, selectedIndex, -1)
+        if (key.upArrow || (!searchable && input === 'k')) {
+          nextIndex = findNextValidIndex(filteredItems, selectedIndex, -1)
         }
 
-        if (key.downArrow || input === 'j') {
-          nextIndex = findNextValidIndex(items, selectedIndex, 1)
+        if (key.downArrow || (!searchable && input === 'j')) {
+          nextIndex = findNextValidIndex(filteredItems, selectedIndex, 1)
         }
       } else {
-        if (key.leftArrow || input === 'h') {
-          nextIndex = findNextValidIndex(items, selectedIndex, -1)
+        if (key.leftArrow || (!searchable && input === 'h')) {
+          nextIndex = findNextValidIndex(filteredItems, selectedIndex, -1)
         }
 
-        if (key.rightArrow || input === 'l') {
-          nextIndex = findNextValidIndex(items, selectedIndex, 1)
+        if (key.rightArrow || (!searchable && input === 'l')) {
+          nextIndex = findNextValidIndex(filteredItems, selectedIndex, 1)
         }
       }
 
@@ -327,26 +380,37 @@ export function useEnhancedSelectInput<V>({
       if (key.return) {
         if (multiple) {
           // In multi-select mode Enter confirms the full selection
-          const confirmed = items.filter((item) =>
+          const confirmed = filteredItems.filter((item) =>
             checkedKeys.has(itemKey(item))
           )
           onConfirm?.(confirmed)
         } else {
-          const selectedItem = items[selectedIndex]
+          const selectedItem = filteredItems[selectedIndex]
           if (selectedItem && !selectedItem.disabled) {
             onSelect?.(selectedItem)
           }
         }
+
+        return
+      }
+
+      // In searchable mode, capture printable characters as search input.
+      // This must come after navigation key handling.
+      if (searchable && input && !key.ctrl && !key.meta) {
+        setSearchQuery((previous) => previous + input)
+        setSelectedIndex(0)
+        if (limit) setRotateIndex(0)
+        return
       }
 
       // Hotkeys: nav keys for the active orientation take priority.
-      // Hotkeys are not active in multi-select mode to avoid ambiguity.
-      if (!multiple && !isNavKey) {
-        const hotkeyItem = items.find(
+      // Hotkeys are not active in multi-select or searchable mode.
+      if (!multiple && !searchable && !isNavKey) {
+        const hotkeyItem = filteredItems.find(
           (item) => item.hotkey === input && !item.disabled
         )
         if (hotkeyItem) {
-          const hotkeyIndex = items.indexOf(hotkeyItem)
+          const hotkeyIndex = filteredItems.indexOf(hotkeyItem)
           updateSelection(hotkeyIndex)
           onSelect?.(hotkeyItem)
         }
@@ -363,6 +427,7 @@ export function useEnhancedSelectInput<V>({
     itemsAbove,
     itemsBelow,
     checkedKeys,
+    searchQuery,
   }
 }
 
@@ -419,6 +484,8 @@ export function EnhancedSelectInput<V>({
   itemComponent = DefaultItemComponent,
   groupHeaderComponent = DefaultGroupHeaderComponent,
   showScrollIndicators = false,
+  searchable = false,
+  searchPlaceholder = 'Search...',
   // All remaining props are forwarded to the hook
   ...hookProperties
 }: Properties<V>) {
@@ -430,9 +497,10 @@ export function EnhancedSelectInput<V>({
     itemsAbove,
     itemsBelow,
     checkedKeys,
-  } = useEnhancedSelectInput(hookProperties)
+    searchQuery,
+  } = useEnhancedSelectInput({ ...hookProperties, searchable })
 
-  if (!hasItems) {
+  if (!hasItems && !searchable) {
     return <Box />
   }
 
@@ -445,8 +513,29 @@ export function EnhancedSelectInput<V>({
   // Track which groups have already rendered a header in this window.
   const renderedGroups = new Set<string>()
 
+  const searchInput = searchable ? (
+    <Box>
+      <Text dimColor>
+        {searchQuery ? `/ ${searchQuery}` : `/ ${searchPlaceholder}`}
+      </Text>
+    </Box>
+  ) : null
+
+  if (!hasItems) {
+    // Searchable mode with no matching results
+    return (
+      <Box flexDirection="column">
+        {searchInput}
+        <Box>
+          <Text dimColor>No matches</Text>
+        </Box>
+      </Box>
+    )
+  }
+
   return (
     <Box flexDirection={isVertical ? 'column' : 'row'}>
+      {searchInput}
       {showScrollIndicators && itemsAbove > 0 && (
         <Box marginRight={isVertical ? 0 : 1}>
           <Text dimColor>

--- a/src/test/enhanced-select-input.test.tsx
+++ b/src/test/enhanced-select-input.test.tsx
@@ -1240,6 +1240,8 @@ type HookHarnessProperties = {
   readonly limit?: number
   readonly isFocused?: boolean
   readonly orientation?: 'vertical' | 'horizontal'
+  // eslint-disable-next-line react/boolean-prop-naming
+  readonly searchable?: boolean
   readonly onResult: (result: UseEnhancedSelectInputResult<unknown>) => void
 }
 
@@ -2758,4 +2760,533 @@ test('selection resets when items are completely replaced', async (t) => {
 
   await delay()
   t.is(highlighted, 'X')
+})
+
+// --- Searchable Mode (#14) ---
+
+test('searchable: renders search input with placeholder', (t) => {
+  const items = [
+    { label: 'Apple', value: 'apple' },
+    { label: 'Banana', value: 'banana' },
+  ]
+
+  const { lastFrame } = render(<EnhancedSelectInput searchable items={items} />)
+
+  const frame = lastFrame()!
+  t.true(frame.includes('/ Search...'))
+  t.true(frame.includes('Apple'))
+  t.true(frame.includes('Banana'))
+})
+
+test('searchable: renders custom placeholder', (t) => {
+  const items = [{ label: 'Apple', value: 'apple' }]
+
+  const { lastFrame } = render(
+    <EnhancedSelectInput
+      searchable
+      items={items}
+      searchPlaceholder="Type to filter"
+    />
+  )
+
+  const frame = lastFrame()!
+  t.true(frame.includes('/ Type to filter'))
+})
+
+test('searchable: typing filters items by label', async (t) => {
+  const items = [
+    { label: 'Apple', value: 'apple' },
+    { label: 'Banana', value: 'banana' },
+    { label: 'Avocado', value: 'avocado' },
+  ]
+
+  const { stdin, lastFrame } = render(
+    <EnhancedSelectInput searchable items={items} />
+  )
+
+  await delay()
+  stdin.write('a')
+  await delay()
+
+  const frame = lastFrame()!
+  t.true(frame.includes('/ a'))
+  t.true(frame.includes('Apple'))
+  t.true(frame.includes('Avocado'))
+  t.true(frame.includes('Banana')) // "Banana" contains 'a'
+})
+
+test('searchable: filtering is case-insensitive', async (t) => {
+  const items = [
+    { label: 'Apple', value: 'apple' },
+    { label: 'Banana', value: 'banana' },
+  ]
+
+  const { stdin, lastFrame } = render(
+    <EnhancedSelectInput searchable items={items} />
+  )
+
+  await delay()
+  stdin.write('APP')
+  await delay()
+
+  const frame = lastFrame()!
+  t.true(frame.includes('Apple'))
+  t.false(frame.includes('Banana'))
+})
+
+test('searchable: multi-character query narrows results', async (t) => {
+  const items = [
+    { label: 'Apple', value: 'apple' },
+    { label: 'Apricot', value: 'apricot' },
+    { label: 'Banana', value: 'banana' },
+  ]
+
+  const { stdin, lastFrame } = render(
+    <EnhancedSelectInput searchable items={items} />
+  )
+
+  await delay()
+  stdin.write('ap')
+  await delay()
+
+  const frame = lastFrame()!
+  t.true(frame.includes('Apple'))
+  t.true(frame.includes('Apricot'))
+  t.false(frame.includes('Banana'))
+
+  stdin.write('p')
+  await delay()
+
+  const frame2 = lastFrame()!
+  // "app" matches Apple but not Apricot
+  t.true(frame2.includes('Apple'))
+  t.false(frame2.includes('Apricot'))
+})
+
+test('searchable: backspace removes last character from query', async (t) => {
+  const items = [
+    { label: 'Apple', value: 'apple' },
+    { label: 'Banana', value: 'banana' },
+  ]
+
+  const { stdin, lastFrame } = render(
+    <EnhancedSelectInput searchable items={items} />
+  )
+
+  await delay()
+  stdin.write('app')
+  await delay()
+
+  let frame = lastFrame()!
+  t.true(frame.includes('Apple'))
+  t.false(frame.includes('Banana'))
+
+  // Backspace to "ap"
+  stdin.write('\u007F') // DEL/Backspace
+  await delay()
+
+  frame = lastFrame()!
+  t.true(frame.includes('/ ap'))
+  t.true(frame.includes('Apple'))
+  t.false(frame.includes('Banana'))
+})
+
+test('searchable: escape clears the search query', async (t) => {
+  const items = [
+    { label: 'Apple', value: 'apple' },
+    { label: 'Banana', value: 'banana' },
+  ]
+
+  const { stdin, lastFrame } = render(
+    <EnhancedSelectInput searchable items={items} />
+  )
+
+  await delay()
+  stdin.write('app')
+  await delay()
+
+  let frame = lastFrame()!
+  t.false(frame.includes('Banana'))
+
+  stdin.write(ESCAPE)
+  await delay()
+
+  frame = lastFrame()!
+  // Query cleared — all items visible again
+  t.true(frame.includes('Apple'))
+  t.true(frame.includes('Banana'))
+  t.true(frame.includes('/ Search...'))
+})
+
+test('searchable: escape calls onCancel when query is already empty', async (t) => {
+  const items = [{ label: 'Apple', value: 'apple' }]
+
+  let cancelled = false
+  const { stdin } = render(
+    <EnhancedSelectInput
+      searchable
+      items={items}
+      onCancel={() => {
+        cancelled = true
+      }}
+    />
+  )
+
+  await delay()
+  // No query typed, escape should call onCancel
+  stdin.write(ESCAPE)
+  await delay()
+  t.true(cancelled)
+})
+
+test('searchable: escape clears query first, then onCancel on second press', async (t) => {
+  const items = [{ label: 'Apple', value: 'apple' }]
+
+  let cancelled = false
+  const { stdin, lastFrame } = render(
+    <EnhancedSelectInput
+      searchable
+      items={items}
+      onCancel={() => {
+        cancelled = true
+      }}
+    />
+  )
+
+  await delay()
+  stdin.write('a')
+  await delay()
+
+  // First escape clears query
+  stdin.write(ESCAPE)
+  await delay()
+  t.false(cancelled)
+  t.true(lastFrame()!.includes('/ Search...'))
+
+  // Second escape calls onCancel
+  stdin.write(ESCAPE)
+  await delay()
+  t.true(cancelled)
+})
+
+test('searchable: arrow navigation works on filtered results', async (t) => {
+  const items = [
+    { label: 'Apple', value: 'apple' },
+    { label: 'Apricot', value: 'apricot' },
+    { label: 'Banana', value: 'banana' },
+  ]
+
+  let highlighted = ''
+  const { stdin } = render(
+    <EnhancedSelectInput
+      searchable
+      items={items}
+      onHighlight={(item) => {
+        highlighted = item.label
+      }}
+    />
+  )
+
+  await delay()
+  stdin.write('ap')
+  await delay()
+  // After filtering, first match should be highlighted
+  t.is(highlighted, 'Apple')
+
+  stdin.write(ARROW_DOWN)
+  await delay()
+  t.is(highlighted, 'Apricot')
+
+  stdin.write(ARROW_UP)
+  await delay()
+  t.is(highlighted, 'Apple')
+})
+
+test('searchable: enter selects from filtered results', async (t) => {
+  const items = [
+    { label: 'Apple', value: 'apple' },
+    { label: 'Banana', value: 'banana' },
+    { label: 'Cherry', value: 'cherry' },
+  ]
+
+  let selected = ''
+  const { stdin } = render(
+    <EnhancedSelectInput
+      searchable
+      items={items}
+      onSelect={(item) => {
+        selected = item.label
+      }}
+    />
+  )
+
+  await delay()
+  stdin.write('ban')
+  await delay()
+  stdin.write(ENTER)
+  await delay()
+  t.is(selected, 'Banana')
+})
+
+test('searchable: vim keys (j/k) are treated as search input, not navigation', async (t) => {
+  const items = [
+    { label: 'jelly', value: 'jelly' },
+    { label: 'jam', value: 'jam' },
+    { label: 'juice', value: 'juice' },
+  ]
+
+  const { stdin, lastFrame } = render(
+    <EnhancedSelectInput searchable items={items} />
+  )
+
+  await delay()
+  stdin.write('j')
+  await delay()
+
+  const frame = lastFrame()!
+  // 'j' should be in the search query, not navigate
+  t.true(frame.includes('/ j'))
+  // All items contain 'j' so all should be visible
+  t.true(frame.includes('jelly'))
+  t.true(frame.includes('jam'))
+  t.true(frame.includes('juice'))
+})
+
+test('searchable: hotkeys are disabled', async (t) => {
+  const items = [
+    { label: 'Apple', value: 'apple', hotkey: 'a' },
+    { label: 'Banana', value: 'banana', hotkey: 'b' },
+  ]
+
+  let selected = ''
+  const { stdin, lastFrame } = render(
+    <EnhancedSelectInput
+      searchable
+      items={items}
+      onSelect={(item) => {
+        selected = item.label
+      }}
+    />
+  )
+
+  await delay()
+  stdin.write('a')
+  await delay()
+
+  // 'a' should filter, not trigger hotkey
+  t.is(selected, '')
+  const frame = lastFrame()!
+  t.true(frame.includes('/ a'))
+})
+
+test('searchable: shows "No matches" when query matches nothing', async (t) => {
+  const items = [
+    { label: 'Apple', value: 'apple' },
+    { label: 'Banana', value: 'banana' },
+  ]
+
+  const { stdin, lastFrame } = render(
+    <EnhancedSelectInput searchable items={items} />
+  )
+
+  await delay()
+  stdin.write('xyz')
+  await delay()
+
+  const frame = lastFrame()!
+  t.true(frame.includes('No matches'))
+  t.true(frame.includes('/ xyz'))
+  t.false(frame.includes('Apple'))
+  t.false(frame.includes('Banana'))
+})
+
+test('searchable: selection resets to first item when query changes', async (t) => {
+  const items = [
+    { label: 'Apple', value: 'apple' },
+    { label: 'Apricot', value: 'apricot' },
+    { label: 'Banana', value: 'banana' },
+  ]
+
+  let highlighted = ''
+  const { stdin } = render(
+    <EnhancedSelectInput
+      searchable
+      items={items}
+      onHighlight={(item) => {
+        highlighted = item.label
+      }}
+    />
+  )
+
+  await delay()
+  stdin.write(ARROW_DOWN)
+  await delay()
+  t.is(highlighted, 'Apricot')
+
+  // Typing resets selection to first match
+  stdin.write('b')
+  await delay()
+  t.is(highlighted, 'Banana')
+})
+
+test('searchable: works with disabled items', async (t) => {
+  const items = [
+    { label: 'Apple', value: 'apple', disabled: true },
+    { label: 'Apricot', value: 'apricot' },
+    { label: 'Banana', value: 'banana' },
+  ]
+
+  let highlighted = ''
+  const { stdin } = render(
+    <EnhancedSelectInput
+      searchable
+      items={items}
+      onHighlight={(item) => {
+        highlighted = item.label
+      }}
+    />
+  )
+
+  await delay()
+  stdin.write('ap')
+  await delay()
+  // Apple is disabled, so Apricot should be highlighted
+  t.is(highlighted, 'Apricot')
+})
+
+test('searchable: space is treated as search character, not toggle', async (t) => {
+  const items = [
+    { label: 'Ice Cream', value: 'ice-cream' },
+    { label: 'Iced Tea', value: 'iced-tea' },
+    { label: 'Apple', value: 'apple' },
+  ]
+
+  let result: UseEnhancedSelectInputResult<unknown> | undefined
+  const { stdin } = render(
+    <HookHarness
+      searchable
+      items={items}
+      onResult={(r) => {
+        result = r
+      }}
+    />
+  )
+
+  await delay()
+  stdin.write('i')
+  await delay()
+  stdin.write('c')
+  await delay()
+  stdin.write('e')
+  await delay()
+  stdin.write(SPACE)
+  await delay()
+
+  // Verify space was captured in the query (not treated as toggle)
+  t.is(result?.searchQuery, 'ice ')
+  // "ice " matches only "Ice Cream" (not "Iced Tea" since "iced tea" doesn't contain "ice ")
+  t.is(result?.visibleItems.length, 1)
+  t.is(result?.visibleItems[0]?.label, 'Ice Cream')
+})
+
+test('searchable: hook exposes searchQuery in result', async (t) => {
+  const items = [
+    { label: 'Apple', value: 'apple' },
+    { label: 'Banana', value: 'banana' },
+  ]
+
+  let result: UseEnhancedSelectInputResult<unknown> | undefined
+  const { stdin } = render(
+    <HookHarness
+      searchable
+      items={items}
+      onResult={(r) => {
+        result = r
+      }}
+    />
+  )
+
+  await delay()
+  t.is(result?.searchQuery, '')
+
+  stdin.write('app')
+  await delay()
+  t.is(result?.searchQuery, 'app')
+})
+
+test('searchable: non-searchable mode does not show search input', (t) => {
+  const items = [{ label: 'Apple', value: 'apple' }]
+
+  const { lastFrame } = render(<EnhancedSelectInput items={items} />)
+
+  const frame = lastFrame()!
+  t.false(frame.includes('/'))
+  t.false(frame.includes('Search'))
+})
+
+test('searchable: works with limit/pagination', async (t) => {
+  const items = [
+    { label: 'Alpha', value: 'alpha' },
+    { label: 'Bravo', value: 'bravo' },
+    { label: 'Charlie', value: 'charlie' },
+    { label: 'Delta', value: 'delta' },
+    { label: 'Able', value: 'able' },
+  ]
+
+  const { stdin, lastFrame } = render(
+    <EnhancedSelectInput searchable items={items} limit={2} />
+  )
+
+  await delay()
+  stdin.write('a')
+  await delay()
+
+  const frame = lastFrame()!
+  // "a" matches Alpha, Bravo (has 'a'), Charlie (has 'a'), Delta (has 'a'), Able
+  // With limit=2, only first 2 should be visible
+  t.true(frame.includes('/ a'))
+})
+
+test('searchable: groups still render with filtered items', async (t) => {
+  const items = [
+    { label: 'Apple', value: 'apple', group: 'Fruits' },
+    { label: 'Apricot', value: 'apricot', group: 'Fruits' },
+    { label: 'Broccoli', value: 'broccoli', group: 'Vegetables' },
+  ]
+
+  const { stdin, lastFrame } = render(
+    <EnhancedSelectInput searchable items={items} />
+  )
+
+  await delay()
+  stdin.write('ap')
+  await delay()
+
+  const frame = lastFrame()!
+  t.true(frame.includes('── Fruits ──'))
+  t.true(frame.includes('Apple'))
+  t.true(frame.includes('Apricot'))
+  t.false(frame.includes('Broccoli'))
+  t.false(frame.includes('── Vegetables ──'))
+})
+
+test('searchable: backspace on empty query does nothing', async (t) => {
+  const items = [
+    { label: 'Apple', value: 'apple' },
+    { label: 'Banana', value: 'banana' },
+  ]
+
+  const { stdin, lastFrame } = render(
+    <EnhancedSelectInput searchable items={items} />
+  )
+
+  await delay()
+  // Backspace with no query
+  stdin.write('\u007F')
+  await delay()
+
+  const frame = lastFrame()!
+  t.true(frame.includes('Apple'))
+  t.true(frame.includes('Banana'))
+  t.true(frame.includes('/ Search...'))
 })


### PR DESCRIPTION
## Summary

Implements #14 — adds searchable/filterable mode for inline item filtering.

## Changes

- `searchable?: boolean` prop enables inline search
- `searchPlaceholder?: string` customizes placeholder text
- Case-insensitive substring matching on item labels
- Search input renders above item list (`/ query`)
- "No matches" shown when query matches nothing
- Backspace removes last char, Escape clears query (then onCancel)
- Vim keys and hotkeys disabled in searchable mode (chars go to query)
- Space treated as search character
- Selection resets to first match on query change
- `searchQuery` exposed in hook result
- Works with limit, groups, and disabled items
- 22 new tests (106 → 128 total)
- Documented in README

## Testing

```
yarn test  # 128 tests passed
yarn lint  # clean
```

Closes #14
