### PR TITLE
chore: exclude dist/test and dist/storybook from npm tarball

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,9 @@
     "test:fix": "yarn lint:fix && ava --update-snapshots"
   },
   "files": [
-    "dist"
+    "dist/index.js",
+    "dist/index.d.ts",
+    "dist/enhanced-select-input"
   ],
   "dependencies": {
     "ink": "^6.0.0",


### PR DESCRIPTION
## Summary

- Tightens the `files` field in `package.json` to list only the public entry points instead of the entire `dist/` directory
- Removes compiled test output (`dist/test/enhanced-select-input.test.js` at ~88 kB) and storybook binary (`dist/storybook.*`) from the published npm package
- Verified with `npm pack --dry-run` — tarball now contains only `dist/index.js`, `dist/index.d.ts`, and `dist/enhanced-select-input/`

## Test plan

- [x] Run `npm run build` in worktree — succeeds
- [x] Run `npm pack --dry-run` — tarball lists 7 files, no `dist/test/*` or `dist/storybook.*`

🤖 Generated with [Claude Code](https://claude.com/claude-code)